### PR TITLE
FFM-6436 Target Android 19 Min Version / Target FF Android SDK v1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.5
+
+* Changed minimum Android API version to 19 
+* Wrapped Android SDK version updated to 1.0.16
+
 ## 1.0.4
 
 Changes:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.0.10'
+    implementation 'io.harness:ff-android-client-sdk:1.0.16'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 19
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 1.0.6
+version: 1.0.5
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 1.0.4
+version: 1.0.6
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:


### PR DESCRIPTION
# What
- Uses min version 19 of Android API. The customer requires a min version of 21, but the Android SDK targets 19, so I am setting it to use that.
- Upgrades FF Android SDK to 1.0.16

# Why
- Customer POC needs to target min Android API version 21 
- Use latest version of FF Android SDK

# Testing
I was able to replicate version error in a newly created flutter app. However, until this is released to the remote repo I can't verify. So will create a pre-release and verify then
