### PR TITLE
FFM-6395 Add check if exception exists on client initialize callback

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -110,6 +110,9 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
 
                         }
                     }
+                    else {
+                        result.success(execResult.isSuccess)
+                    }
                 }
         }
     }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -89,24 +89,28 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
 
             val targetInstance = Target().identifier(target)
 
-            CfClient.getInstance().initialize(
 
-                application,
-                key,
-                conf,
-                targetInstance
+                CfClient.getInstance().initialize(
 
-            ) { auth, execResult ->
+                    application,
+                    key,
+                    conf,
+                    targetInstance
 
-                postToMainThread {
-                    print(auth.environment)
+                ) { auth, execResult ->
+                    if (execResult.error == null) {
 
-                    Handler(Looper.getMainLooper()).post {
+                        postToMainThread {
+                            print(auth.environment)
 
-                        result.success(execResult.isSuccess())
+                            Handler(Looper.getMainLooper()).post {
+
+                                result.success(execResult.isSuccess())
+                            }
+
+                        }
                     }
                 }
-            }
         }
     }
 


### PR DESCRIPTION
# What
I've changed the Android SDK so that it returns an exception on the auth callback if there has been a valid exception, this change adds a check to see if the auth callback has an exception

# Why 
So we fail fast instead of continuing on when there is no auth token to process

# Testing 
Manual testing. 

# Future enhancement 
I am currently building a retry mechanism into the Android SDK which will only return once the retries are exhausted. I wonder do we want to add a mechanism here.