### PR TITLE
FFM-6395 - Return PlatformError from plugin to dart code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.0.7
+
+Fixes:
+
+* Applications no longer crash due to API related exceptions caused by e.g. having no internet connectivity / bad API key etc.
+* Streaming now resumes if internet connectivity is lost
+
+Changes:
+
+* Wrapped Android SDK version updated to 1.0.19
+
+Known issues:
+
+* If internet connectivity is lost and a change in flag state has occurred during that period, you must
+disconnect and reconnect to the internet to cache latest changes. Any events streamed after losing connectivity are correctly cached.
+* SDK Client does not retry if initialization fails. To remediate in the short term, client init may be wrapped in an application's own retry logic.
+
 ## 1.0.6
 Changes:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To follow along with our test code sample, make sure you've:
 ## Installing the SDK
 To add the SDK to your own project run
 ```Dart
-ff_flutter_client_sdk: ^1.0.6
+ff_flutter_client_sdk: ^1.0.7
 ```
 
 Then, you may import package to your project

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 
     dependencies {
@@ -18,6 +19,7 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.0.17'
+    implementation 'io.harness:ff-android-client-sdk:1.0.18'
 }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -111,7 +111,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                         }
                     }
                     else {
-                        result.success(execResult.isSuccess)
+                        result.error("authError","Error when initializing SDK", execResult.error.localizedMessage )
                     }
                 }
         }
@@ -358,3 +358,4 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
         channel.setMethodCallHandler(null)
     }
 }
+

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -144,7 +144,6 @@ class CfClient {
     });
 
     return new Future(() => InitializationResult(initialized));
-  }
 }
 
   /// Performs string evaluation for given evaluation id. If no such id is present, the default value will be returned.

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'package:flutter/services.dart';
 
+
 part 'CfTarget.dart';
 
 part 'CfConfiguration.dart';
@@ -131,10 +132,11 @@ class CfClient {
 
   /// Initializes the SDK client with provided API key, configuration and target. Returns information if
   /// initialization succeeded or not
-  Future<InitializationResult> initialize(
-      String apiKey, CfConfiguration configuration, CfTarget target) async {
+  Future<InitializationResult> initialize(String apiKey,
+      CfConfiguration configuration, CfTarget target) async {
     _hostChannel.setMethodCallHandler(_hostChannelHandler);
 
+    // TODO - we need a try-catch here on PlatformException in order to retry.
     bool initialized = await _channel.invokeMethod('initialize', {
       'apiKey': apiKey,
       'configuration': configuration._toCodecValue(),
@@ -143,6 +145,7 @@ class CfClient {
 
     return new Future(() => InitializationResult(initialized));
   }
+}
 
   /// Performs string evaluation for given evaluation id. If no such id is present, the default value will be returned.
   Future<String> stringVariation(String id, String defaultValue) async {

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -151,7 +151,7 @@ class CfClient {
       'target': target._toCodecValue()
     }); } on PlatformException catch(e) {
       // For now just log the error. In the future, we should add retry and backoff logic.
-      log.severe(e.message, [e.details]);
+      log.severe(e.message + "" + e.details,);
       return new Future(() => InitializationResult(initialized));
     }
 }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -152,9 +152,10 @@ class CfClient {
     }); } on PlatformException catch(e) {
       // For now just log the error. In the future, we should add retry and backoff logic.
       log.severe(e.message + "" + e.details,);
-      return new Future(() => InitializationResult(initialized));
+      return new Future(() => InitializationResult(false));
     }
-}
+    return new Future(() => InitializationResult(initialized));
+  }
 
   /// Performs string evaluation for given evaluation id. If no such id is present, the default value will be returned.
   Future<String> stringVariation(String id, String defaultValue) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 1.0.6
+version: 1.0.7
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  logging: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# What
In client init, if the Android plugin detects an error from the authcallback from the Android SDK we now return the error using the correct API. This will mean Flutter does the equivalent of an error.log() and logs the error to the console, but the application will not crash.

# Why
So any init errors are logged correctly

# Testing
Manual 