### PR TITLE
FFM-6574 - Use new Android SDK SSE_RESUME Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.0.9
+
+Changes:
+
+* Adds new event SSE_RESUME event which fires if the application loses and regains internet. When fired this event does two things:
+  * Internally reloads all applications into cache.
+  * Applications can listen to this event to ensure event listeners don't miss any streamed events during periods of downtime. E.g. call a variation function to get latest evaluation result.
+* Wrapped Android SDK version updated to 1.0.19
+
+
+Known issues:
+
+* If internet connectivity is lost and regained, it can take up to 10 seconds for the SSE_RESUME event to fire and for latest evaluations to be reloaded into cache
+* SDK Client does not retry if initialization fails. To remediate in the short term, client init may be wrapped in an application's own retry logic.
+
 ## 1.0.8
 
 Fixes:
@@ -13,7 +28,7 @@ Known issues:
 
 * If internet connectivity is lost and a change in flag state has occurred during that period, you must
   disconnect and reconnect to the internet to cache latest changes. Any events streamed after losing connectivity are correctly cached.
-* SDK Client does not retry if initial
+* Streaming now resumes if internet connectivity is lost
 
 ## 1.0.7f
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To follow along with our test code sample, make sure you've:
 ## Installing the SDK
 To add the SDK to your own project run
 ```Dart
-ff_flutter_client_sdk: ^1.0.8
+ff_flutter_client_sdk: ^1.0.9
 ```
 
 Then, you may import package to your project

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 }
 
@@ -38,5 +39,5 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.0.18'
+    implementation 'io.harness:ff-android-client-sdk:1.0.19'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,6 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
-        mavenLocal()
     }
 }
 

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -138,6 +138,11 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                         hostChannel.invokeMethod("end", null)
                     }
                 }
+                StatusEvent.EVENT_TYPE.SSE_RESUME -> {
+                    postToMainThread {
+                        hostChannel.invokeMethod("resume", null)
+                    }
+                }
                 StatusEvent.EVENT_TYPE.EVALUATION_CHANGE -> {
 
                     val evaluation = it.extractPayload<Evaluation>()

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -106,6 +106,7 @@ Triggered event will have one of the following types.
 ```Dart
 enum EventType {
     SSE_START,
+    SSE_RESUME
     SSE_END,
     EVALUATION_POLLING,
     EVALUATION_CHANGE
@@ -117,12 +118,13 @@ Each type will return a corresponding value as shown in the table below.
 | EventType          | Returns                  |
 | :----------------  | :-----------------------:|
 | SSE_START          | null                     |
+| SSE_RESUME         | null                     |
 | SSE_END            | null                     |
 | EVALUATION_POLLING | List<EvaluationResponse> |
 | EVALUATION_CHANGE  | EvaluationResponse       |
 
 ```
-Visit documentation for complete list of possible types and values they provide.
+Visit [Harness Feature Flags Android SDK](https://github.com/harness/ff-android-client-sdk/blob/main/docs/further_reading.md#further-reading) for a complete list of possible types and values they provide.
 
 To avoid unexpected behaviour, when listener is not needed anymore, a caller should call
 `CfClient.getInstance().unregisterEventsListener(eventsListener)`

--- a/examples/getting_started/lib/main.dart
+++ b/examples/getting_started/lib/main.dart
@@ -69,6 +69,17 @@ class _FlagState extends State<FlagState> {
                         });
                     }
                     break;
+          // There's been an interruption in the SSE but which has since resumed, which means the
+          // cache will have been updated with the latest values, so we can call
+          // bool variation to get the most up to date evaluation value.
+            case EventType.SSE_RESUME:
+              CfClient.getInstance().boolVariation(flagName, false).then((value) {
+                print("$flagName: $value");
+                setState(() {
+                  _flagValue = value;
+                });
+              });
+              break;
           }
         });
       }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -104,7 +104,7 @@ class CfClient {
       });
     } else if (methodCall.method == "resume") {
       _listenerSet.forEach((element) {
-        element(null, EventType.SSE_END);
+        element(null, EventType.SSE_RESUME);
       });
     }
     else if (methodCall.method == "evaluation_change") {

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -47,6 +47,9 @@ enum EventType {
   /// Indicates that realtime evaluation update monitor is started. Has no payload.
   SSE_START,
 
+  /// Indicates that realtime evaluation update monitor has restarted after recovering from network failure. Has no payload.
+  SSE_RESUME,
+
   /// Indicates that realtime evaluation update monitor is ended. Has no payload.
   SSE_END,
 
@@ -99,7 +102,12 @@ class CfClient {
       _listenerSet.forEach((element) {
         element(null, EventType.SSE_END);
       });
-    } else if (methodCall.method == "evaluation_change") {
+    } else if (methodCall.method == "resume") {
+      _listenerSet.forEach((element) {
+        element(null, EventType.SSE_END);
+      });
+    }
+    else if (methodCall.method == "evaluation_change") {
       String flag = methodCall.arguments["flag"];
       dynamic value = methodCall.arguments["value"];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 1.0.8
+version: 1.0.9
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:


### PR DESCRIPTION
# What
The Android SDK now emits an `SSE_RESUME` event to signal to event listeners that there has been an interruption but it has recovered. The Flutter SDK can now listen for this new event.

Updated example app to consume new event with comment, and `further_reading.md` now links to the Android SDK further reading section on events emitted. 

# Testing
Manual 