### PR TITLE
FFM-6822 - Update Flutter SDK to use Android SDK 1.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.0.10
+
+Changes:
+
+* Wrapped Android SDK version updated to 1.0.20 - this release fixes excessive network calls when calling flag evaluation functions
+
+
+Known issues:
+
+* If internet connectivity is lost and regained, it can take up to 10 seconds for the SSE_RESUME event to fire and for latest evaluations to be reloaded into cache
+* SDK Client does not retry if initialization fails. To remediate in the short term, client init may be wrapped in an application's own retry logic.
+
+
 ## 1.0.9
 
 Changes:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To follow along with our test code sample, make sure you've:
 ## Installing the SDK
 To add the SDK to your own project run
 ```Dart
-ff_flutter_client_sdk: ^1.0.9
+ff_flutter_client_sdk: ^1.0.10
 ```
 
 Then, you may import package to your project

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,6 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.0.19'
+    implementation 'io.harness:ff-android-client-sdk:1.0.20'
+
 }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -22,9 +22,11 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.lang.Exception
 import java.util.concurrent.*;
+import io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
 
 /** FfFlutterClientSdkPlugin */
 class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
+
     private lateinit var application: Application
 
     /// The MethodChannel that will the communication between Flutter and native Android
@@ -75,6 +77,8 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun invokeInitialize(@NonNull call: MethodCall, @NonNull result: Result) {
+
+        println("Using Android SDK version ${ANDROID_SDK_VERSION}")
 
         val config: Map<String, Any>? = call.argument("configuration")
         val key: String? = call.argument("apiKey")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 1.0.9
+version: 1.0.10
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:


### PR DESCRIPTION
What
Update embedded Android SDK version to 1.0.20

Why
This newer version of Android SDK includes performance fixes to prevent unnecessary API evalution callouts to the FF server.

Testing
Manual - most of the logic and unit testing was done in the Android SDK