### PR TITLE
FFM-8191 Add null safety 

### DIFF
--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -14,11 +14,11 @@ final log = Logger('CFClientLogger');
 
 
 class InitializationResult {
-  InitializationResult(bool value) {
+  InitializationResult(bool/*!*/ value) {
     this.success = value;
   }
 
-  bool success;
+  bool success = false;
 }
 
 class EvaluationRequest {
@@ -36,7 +36,7 @@ class EvaluationRequest {
 /// changed evaluation's flag and its value. The value type is dynamic and it is
 /// SDK's end-user responsibility to know what type is used for given id
 class EvaluationResponse {
-  String flag;
+  String/*!*/ flag;
   dynamic value;
 
   EvaluationResponse(this.flag, this.value);
@@ -84,7 +84,7 @@ typedef void CfEventsListener(dynamic data, EventType eventType);
 ///```
 class CfClient {
 
-  static CfClient _instance;
+  static CfClient/*?*/ _instance;
 
   MethodChannel _channel =
       const MethodChannel('ff_flutter_client_sdk');
@@ -133,13 +133,13 @@ class CfClient {
     }
   }
 
-  static CfClient getInstance() {
+  static CfClient/*!*/ getInstance() {
 
     if (_instance == null) {
 
       _instance = CfClient();
     }
-    return _instance;
+    return _instance/*!*/;
   }
 
   /// Initializes the SDK client with provided API key, configuration and target. Returns information if
@@ -151,7 +151,7 @@ class CfClient {
       print('${record.level.name}: ${record.time}: ${record.message}');
     });
     _hostChannel.setMethodCallHandler(_hostChannelHandler);
-    bool initialized = false;
+    bool/*!*/ initialized = false;
     try {
     initialized = await _channel.invokeMethod('initialize', {
       'apiKey': apiKey,
@@ -159,10 +159,10 @@ class CfClient {
       'target': target._toCodecValue()
     }); } on PlatformException catch(e) {
       // For now just log the error. In the future, we should add retry and backoff logic.
-      log.severe(e.message + "" + e.details,);
+      log.severe(e.message ?? 'Error message was empty' + (e.details ?? 'Error details was empty').toString());
       return new Future(() => InitializationResult(false));
     }
-    return new Future(() => InitializationResult(initialized));
+    return new Future(() => InitializationResult(initialized/*!*/));
   }
 
   /// Performs string evaluation for given evaluation id. If no such id is present, the default value will be returned.
@@ -189,7 +189,7 @@ class CfClient {
         'jsonVariation', new EvaluationRequest(flag, defaultValue));
   }
 
-  Future<T> _sendMessage<T>(
+  Future<T/*!*/> _sendMessage<T>(
       String messageType, EvaluationRequest evaluationRequest) async {
     return _channel.invokeMethod(messageType, evaluationRequest.toMap());
   }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -191,8 +191,8 @@ class CfClient {
 
   Future<T> _sendMessage<T>(
       String messageType, EvaluationRequest evaluationRequest) async {
-    dynamic result = await _channel.invokeMethod(messageType, evaluationRequest.toMap());
-    return result as T;
+    return _channel.invokeMethod(messageType, evaluationRequest.toMap())
+        .then((result) => result as T);
   }
 
   /// Register a listener for different types of events. Possible types are based on [EventType] class

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -14,7 +14,7 @@ final log = Logger('CFClientLogger');
 
 
 class InitializationResult {
-  InitializationResult(bool/*!*/ value) {
+  InitializationResult(bool value) {
     this.success = value;
   }
 
@@ -36,7 +36,7 @@ class EvaluationRequest {
 /// changed evaluation's flag and its value. The value type is dynamic and it is
 /// SDK's end-user responsibility to know what type is used for given id
 class EvaluationResponse {
-  String/*!*/ flag;
+  String flag;
   dynamic value;
 
   EvaluationResponse(this.flag, this.value);
@@ -84,7 +84,7 @@ typedef void CfEventsListener(dynamic data, EventType eventType);
 ///```
 class CfClient {
 
-  static CfClient/*?*/ _instance;
+  static CfClient? _instance;
 
   MethodChannel _channel =
       const MethodChannel('ff_flutter_client_sdk');
@@ -133,13 +133,13 @@ class CfClient {
     }
   }
 
-  static CfClient/*!*/ getInstance() {
+  static CfClient getInstance() {
 
     if (_instance == null) {
 
       _instance = CfClient();
     }
-    return _instance/*!*/;
+    return _instance!;
   }
 
   /// Initializes the SDK client with provided API key, configuration and target. Returns information if
@@ -151,18 +151,18 @@ class CfClient {
       print('${record.level.name}: ${record.time}: ${record.message}');
     });
     _hostChannel.setMethodCallHandler(_hostChannelHandler);
-    bool/*!*/ initialized = false;
+    bool initialized = false;
     try {
-    initialized = await _channel.invokeMethod('initialize', {
+    initialized = await (_channel.invokeMethod('initialize', {
       'apiKey': apiKey,
       'configuration': configuration._toCodecValue(),
       'target': target._toCodecValue()
-    }); } on PlatformException catch(e) {
+    }) as FutureOr<bool>); } on PlatformException catch(e) {
       // For now just log the error. In the future, we should add retry and backoff logic.
       log.severe(e.message ?? 'Error message was empty' + (e.details ?? 'Error details was empty').toString());
       return new Future(() => InitializationResult(false));
     }
-    return new Future(() => InitializationResult(initialized/*!*/));
+    return new Future(() => InitializationResult(initialized!));
   }
 
   /// Performs string evaluation for given evaluation id. If no such id is present, the default value will be returned.
@@ -189,9 +189,9 @@ class CfClient {
         'jsonVariation', new EvaluationRequest(flag, defaultValue));
   }
 
-  Future<T/*!*/> _sendMessage<T>(
+  Future<T> _sendMessage<T>(
       String messageType, EvaluationRequest evaluationRequest) async {
-    return _channel.invokeMethod(messageType, evaluationRequest.toMap());
+    return _channel.invokeMethod(messageType, evaluationRequest.toMap()) as FutureOr<T>;
   }
 
   /// Register a listener for different types of events. Possible types are based on [EventType] class

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -157,7 +157,7 @@ class CfClient {
       'apiKey': apiKey,
       'configuration': configuration._toCodecValue(),
       'target': target._toCodecValue()
-    }) as FutureOr<bool>); } on PlatformException catch(e) {
+    })); } on PlatformException catch(e) {
       // For now just log the error. In the future, we should add retry and backoff logic.
       log.severe(e.message ?? 'Error message was empty' + (e.details ?? 'Error details was empty').toString());
       return new Future(() => InitializationResult(false));
@@ -191,7 +191,8 @@ class CfClient {
 
   Future<T> _sendMessage<T>(
       String messageType, EvaluationRequest evaluationRequest) async {
-    return _channel.invokeMethod(messageType, evaluationRequest.toMap()) as FutureOr<T>;
+    dynamic result = await _channel.invokeMethod(messageType, evaluationRequest.toMap());
+    return result as T;
   }
 
   /// Register a listener for different types of events. Possible types are based on [EventType] class

--- a/test/ff_flutter_client_sdk_test.dart
+++ b/test/ff_flutter_client_sdk_test.dart
@@ -14,7 +14,7 @@ void main() {
           return true;
         case "boolVariation":
           Map<dynamic, dynamic> args = methodCall.arguments;
-          String/*!*/ flag = args["flag"];
+          String flag = args["flag"];
           switch (flag) {
             case "demo_first_bool_id":
               return true;
@@ -24,8 +24,8 @@ void main() {
           break;
         case "stringVariation":
           Map<dynamic, dynamic> args = methodCall.arguments;
-          String/*!*/ flag = args["flag"];
-          String/*!*/ defaultValue = args["defaultValue"];
+          String flag = args["flag"];
+          String defaultValue = args["defaultValue"];
           switch (flag) {
             case "demo_first_id":
               return "first_value";

--- a/test/ff_flutter_client_sdk_test.dart
+++ b/test/ff_flutter_client_sdk_test.dart
@@ -14,7 +14,7 @@ void main() {
           return true;
         case "boolVariation":
           Map<dynamic, dynamic> args = methodCall.arguments;
-          String flag = args["flag"];
+          String/*!*/ flag = args["flag"];
           switch (flag) {
             case "demo_first_bool_id":
               return true;
@@ -24,8 +24,8 @@ void main() {
           break;
         case "stringVariation":
           Map<dynamic, dynamic> args = methodCall.arguments;
-          String flag = args["flag"];
-          String defaultValue = args["defaultValue"];
+          String/*!*/ flag = args["flag"];
+          String/*!*/ defaultValue = args["defaultValue"];
           switch (flag) {
             case "demo_first_id":
               return "first_value";


### PR DESCRIPTION
# What
Adds null safety to code so that Dart >= 2.12 can be supported by the SDK, and in turn later versions of Flutter.

# Testing
Tested each lifecycle of the SDK 

- Init
- Each evaluation type - bool/str/int/num/json
- Metrics
- Streaming
