### PR TITLE
FFM-8962 Implement Events

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.0.20'
+    implementation 'io.harness:ff-android-client-sdk:1.1.3'
 
 }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -125,6 +125,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
         return mutableMapOf<String, Any>().apply {
             this["flag"] = evaluation.flag
             this["value"] = evaluation.getValue()
+            this["kind"] = evaluation.kind
         }
     }
 

--- a/examples/getting_started/web/index.html
+++ b/examples/getting_started/web/index.html
@@ -31,6 +31,7 @@
 
   <title>getting_started</title>
   <link rel="manifest" href="manifest.json">
+  <script src="https://unpkg.com/@harnessio/ff-javascript-client-sdk/dist/sdk.client-iife.js"></script>
 
   <script>
     // The value below is injected by flutter build, do not touch.

--- a/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
@@ -146,7 +146,7 @@ public class SwiftFfFlutterClientSdkPlugin: NSObject, FlutterPlugin {
 									guard let eval = eval else { result(nil); return }
 
 									let value = self.extractValue(eval.value)
-									let content = ["flag": eval.flag, "value": value ?? ""]
+									let content = ["flag": eval.flag, "value": value ?? "", "kind": eval.kind]
 
 									DispatchQueue.main.async {
 										self.hostChannel.invokeMethod(EventTypeId.evaluationChange.rawValue, arguments: content)

--- a/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
@@ -146,7 +146,7 @@ public class SwiftFfFlutterClientSdkPlugin: NSObject, FlutterPlugin {
 									guard let eval = eval else { result(nil); return }
 
 									let value = self.extractValue(eval.value)
-									let content = ["flag": eval.flag, "value": value ?? "", "kind"]
+									let content = ["flag": eval.flag, "value": value ?? ""]
 
 									DispatchQueue.main.async {
 										self.hostChannel.invokeMethod(EventTypeId.evaluationChange.rawValue, arguments: content)

--- a/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
@@ -146,7 +146,7 @@ public class SwiftFfFlutterClientSdkPlugin: NSObject, FlutterPlugin {
 									guard let eval = eval else { result(nil); return }
 
 									let value = self.extractValue(eval.value)
-									let content = ["flag": eval.flag, "value": value ?? "", "kind": eval.kind]
+									let content = ["flag": eval.flag, "value": value ?? "", "kind"]
 
 									DispatchQueue.main.async {
 										self.hostChannel.invokeMethod(EventTypeId.evaluationChange.rawValue, arguments: content)

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -240,7 +240,7 @@ class CfClient {
     log.severe("GONNA CONVERT");
     if (value is String) {
       switch (kind) {
-        case 'boolnea':
+        case 'boolean':
           return value.toLowerCase() == 'true';
         case 'string':
         // Value is already a string, so we just return it

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -118,13 +118,13 @@ class CfClient {
       //  minor SDK update there. For now, iOS will use the string SSE
       // values.
       final String? kind = methodCall.arguments["kind"];
-      final dynamic parsedValue = kind != null ? convertValueByKind(kind, value) : value;
+      final dynamic parsedValue =
+          kind != null ? convertValueByKind(kind, value) : value;
       final response = EvaluationResponse(flag, parsedValue);
 
       _listenerSet.forEach((element) {
         element(response, EventType.EVALUATION_CHANGE);
       });
-
     } else if (methodCall.method == "evaluation_polling") {
       List list = methodCall.arguments["evaluationData"] as List;
       List<EvaluationResponse> resultList = [];
@@ -177,7 +177,8 @@ class CfClient {
 
   /// Performs string evaluation for given evaluation id. If no such id is present, the default value will be returned.
   Future<String> stringVariation(String id, String defaultValue) async {
-      return _sendMessage('stringVariation', new EvaluationRequest(id, defaultValue));
+    return _sendMessage(
+        'stringVariation', new EvaluationRequest(id, defaultValue));
   }
 
   /// Performs boolean evaluation for given evaluation id. If no such id is present, the default value will be returned.

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -239,7 +239,7 @@ class CfClient {
   // as strings. This is a function to standardise them into the correct type,
   // so the SSE evaluations are the same underlying type as the variation
   // evaluations.
-  // We return as dynamic in order to keep backwards compatability with, but
+  // We return as dynamic in order to keep backwards compatability, but
   // this means that users don't have to cast values between SSE evaluations
   // ane evaluations made via the public variation functions.
   dynamic convertValueByKind(String kind, dynamic value) {
@@ -251,7 +251,7 @@ class CfClient {
           // Value is already a string, so we just return it
           return value;
         case "int":
-          // Attempt to parse as an int first
+          // Number flags can be integer or floating point
           final intValue = int.tryParse(value);
           if (intValue != null) {
             return intValue;

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -228,7 +228,8 @@ class CfClient {
     // unregisterEventsListener implemented. For now, those platforms have
     // destroy.
     if (kIsWeb && _listenerUuidMap[listener] != null) {
-      return _channel.invokeMethod('unregisterEventsListener', {'uuid': _listenerUuidMap[listener]});
+      return _channel.invokeMethod(
+          'unregisterEventsListener', {'uuid': _listenerUuidMap[listener]});
     }
   }
 
@@ -243,10 +244,10 @@ class CfClient {
         case 'boolean':
           return value.toLowerCase() == 'true';
         case 'string':
-        // Value is already a string, so we just return it
+          // Value is already a string, so we just return it
           return value;
         case "int":
-        // Attempt to parse as an int first
+          // Attempt to parse as an int first
           final intValue = int.tryParse(value);
           if (intValue != null) {
             return intValue;

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -2,6 +2,7 @@ library ff_flutter_client_sdk;
 
 import 'dart:async';
 import 'dart:collection';
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 
@@ -197,6 +198,12 @@ class CfClient {
   /// Register a listener for different types of events. Possible types are based on [EventType] class
   Future<void> registerEventsListener(CfEventsListener listener) async {
     _listenerSet.add(listener);
+    // For the web platform, pass the listener reference so that it can be removed
+    // later, so that the JavaScript SDK can stop emitting events when not needed.
+    // TODO, needs implemented for Android/iOS, but for now, those platforms have destroy.
+    if (kIsWeb) {
+      return _channel.invokeMethod('registerEventsListener', listener);
+    }
     return _channel.invokeMethod('registerEventsListener');
   }
 
@@ -205,6 +212,13 @@ class CfClient {
   Future<void> unregisterEventsListener(
       CfEventsListener listener) async {
     _listenerSet.remove(listener);
+    // For the web platform, ensure the JavaScript SDK stops emitting
+    // events when it is not needed. TODO, for iOS and Android, needs an
+    // unregisterEventsListener implemented. For now, those platforms have
+    // destroy.
+    if (kIsWeb) {
+      return _channel.invokeMethod('unregisterEventsListener', listener);
+    }
   }
 
   /// Client's method to deregister and cleanup internal resources used by SDK

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -146,7 +146,7 @@ class CfClient {
   /// initialization succeeded or not
   Future<InitializationResult> initialize(String apiKey,
       CfConfiguration configuration, CfTarget target) async {
-    Logger.root.level = Level.SEVERE; // defaults to Level.INFO
+    Logger.root.level = configuration.logLevel; // defaults to Level.INFO
     Logger.root.onRecord.listen((record) {
       print('${record.level.name}: ${record.time}: ${record.message}');
     });

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -233,7 +233,7 @@ class CfClient {
     }
   }
 
-  // At present, the Android and iOS SDKs SSE events return evaluation values
+  // At present, the Android and iOS SDKs (not JavaScript) SSE events return evaluation values
   // as strings. This is a function to standardise them into the correct type,
   // so the SSE evaluations are the same underlying type as the variation
   // evaluations.

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -111,12 +111,21 @@ class CfClient {
       });
     } else if (methodCall.method == "evaluation_change") {
       final String flag = methodCall.arguments["flag"];
-      final String kind = methodCall.arguments["kind"];
+
       final dynamic value = methodCall.arguments["value"];
 
-      final dynamic parsedValue = convertValueByKind(kind, value);
+      // TODO - the iOS SDK doesn't emit this so it will need a very
+      //  minor SDK update there. For now, iOS will use the string SSE
+      // values.
+      final String? kind = methodCall.arguments["kind"];
+      late dynamic response;
+      if (kind != null) {
+        final dynamic parsedValue = convertValueByKind(kind, value);
+        response = EvaluationResponse(flag, parsedValue);
+      } else {
+        response = EvaluationResponse(flag, value);
+      }
 
-      final EvaluationResponse response = EvaluationResponse(flag, parsedValue);
 
       _listenerSet.forEach((element) {
         element(response, EventType.EVALUATION_CHANGE);
@@ -127,7 +136,6 @@ class CfClient {
 
       list.forEach((element) {
         String flag = element["flag"];
-        String kind = element["kind"];
         dynamic value = element["value"];
 
         resultList.add(EvaluationResponse(flag, value));

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -114,7 +114,7 @@ class CfClient {
       final String kind = methodCall.arguments["kind"];
       final dynamic value = methodCall.arguments["value"];
 
-      final parsedValue = convertValueByKind(kind, value);
+      final dynamic parsedValue = convertValueByKind(kind, value);
 
       final EvaluationResponse response = EvaluationResponse(flag, parsedValue);
 
@@ -237,8 +237,10 @@ class CfClient {
   // as strings. This is a function to standardise them into the correct type,
   // so the SSE evaluations are the same underlying type as the variation
   // evaluations.
+  // We return as dynamic in order to keep backwards compatability with, but
+  // this means that users don't have to cast values between SSE evaluations
+  // ane evaluations made via the public variation functions.
   dynamic convertValueByKind(String kind, dynamic value) {
-    log.severe("GONNA CONVERT");
     if (value is String) {
       switch (kind) {
         case 'boolean':

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -208,7 +208,9 @@ class CfClient {
     // TODO, registerEventsListener with a function reference
     //  needs implemented for Android/iOS, but for now, those platforms have destroy.
     if (kIsWeb) {
-      return _channel.invokeMethod('registerEventsListener', listener);
+      final uuid = _uuid.v4();
+      _listenerUuidMap[listener] = uuid;
+      return _channel.invokeMethod('registerEventsListener', {'uuid': uuid});
     }
     return _channel.invokeMethod('registerEventsListener');
   }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -118,18 +118,13 @@ class CfClient {
       //  minor SDK update there. For now, iOS will use the string SSE
       // values.
       final String? kind = methodCall.arguments["kind"];
-      late dynamic response;
-      if (kind != null) {
-        final dynamic parsedValue = convertValueByKind(kind, value);
-        response = EvaluationResponse(flag, parsedValue);
-      } else {
-        response = EvaluationResponse(flag, value);
-      }
-
+      final dynamic parsedValue = kind != null ? convertValueByKind(kind, value) : value;
+      final response = EvaluationResponse(flag, parsedValue);
 
       _listenerSet.forEach((element) {
         element(response, EventType.EVALUATION_CHANGE);
       });
+
     } else if (methodCall.method == "evaluation_polling") {
       List list = methodCall.arguments["evaluationData"] as List;
       List<EvaluationResponse> resultList = [];

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -223,7 +223,7 @@ class CfClient {
     // unregisterEventsListener implemented. For now, those platforms have
     // destroy.
     if (kIsWeb && _listenerUuidMap[listener] != null) {
-      return _channel.invokeMethod('unRegisterEventsListener', _listenerUuidMap[listener]);
+      return _channel.invokeMethod('unregisterEventsListener', {'uuid': _listenerUuidMap[listener]});
     }
   }
 

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -5,7 +5,7 @@ import 'dart:collection';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
-
+import 'package:uuid/uuid.dart';
 
 part 'CfTarget.dart';
 
@@ -86,6 +86,11 @@ typedef void CfEventsListener(dynamic data, EventType eventType);
 class CfClient {
 
   static CfClient? _instance;
+
+  // A map to hold UUID against the CfEventsListener references
+  final Map<CfEventsListener, String> _listenerUuidMap = {};
+
+  final _uuid = Uuid();
 
   MethodChannel _channel =
       const MethodChannel('ff_flutter_client_sdk');
@@ -200,7 +205,8 @@ class CfClient {
     _listenerSet.add(listener);
     // For the web platform, pass the listener reference so that it can be removed
     // later, so that the JavaScript SDK can stop emitting events when not needed.
-    // TODO, needs implemented for Android/iOS, but for now, those platforms have destroy.
+    // TODO, registerEventsListener with a function reference
+    //  needs implemented for Android/iOS, but for now, those platforms have destroy.
     if (kIsWeb) {
       return _channel.invokeMethod('registerEventsListener', listener);
     }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -201,16 +201,17 @@ class CfClient {
   /// Register a listener for different types of events. Possible types are based on [EventType] class
   Future<void> registerEventsListener(CfEventsListener listener) async {
     _listenerSet.add(listener);
+
+    if (!kIsWeb) return _channel.invokeMethod('registerEventsListener');
+
     // For the web platform, pass the listener reference so that it can be removed
     // later, so that the JavaScript SDK can stop emitting events when not needed.
-    // TODO, registerEventsListener with a function reference
-    //  needs implemented for Android/iOS, but for now, those platforms have destroy.
-    if (kIsWeb) {
+    // TODO needs implemented for Android/iOS, but for now, those platforms have destroy.
+    if (!_listenerUuidMap.containsKey(listener)) {
       final uuid = _uuid.v4();
       _listenerUuidMap[listener] = uuid;
       return _channel.invokeMethod('registerEventsListener', {'uuid': uuid});
     }
-    return _channel.invokeMethod('registerEventsListener');
   }
 
   /// Removes a previously-registered listener from internal collection of listeners. From this point, provided
@@ -222,7 +223,7 @@ class CfClient {
     // unregisterEventsListener implemented. For now, those platforms have
     // destroy.
     if (kIsWeb && _listenerUuidMap[listener] != null) {
-      return _channel.invokeMethod('unregisterEventsListener', _listenerUuidMap[listener]);
+      return _channel.invokeMethod('unRegisterEventsListener', _listenerUuidMap[listener]);
     }
   }
 

--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -1,7 +1,6 @@
 part of ff_flutter_client_sdk;
 
 class CfConfiguration {
-
   String configUrl;
   String streamUrl;
   String eventUrl;
@@ -14,14 +13,13 @@ class CfConfiguration {
   CfConfiguration._builder(CfConfigurationBuilder builder)
       : configUrl = builder._configUrl,
         streamUrl = builder._streamUrl,
-        eventUrl  = builder._eventUrl,
+        eventUrl = builder._eventUrl,
         streamEnabled = builder._streamEnabled,
         analyticsEnabled = builder._analyticsEnabled,
         pollingInterval = builder._pollingInterval,
         logLevel = builder._logLevel;
 
   Map<String, dynamic> _toCodecValue() {
-
     final Map<String, dynamic> result = <String, dynamic>{};
     result['configUrl'] = configUrl;
     result['streamUrl'] = streamUrl;
@@ -34,7 +32,6 @@ class CfConfiguration {
 }
 
 class CfConfigurationBuilder {
-
   String _configUrl = "https://config.ff.harness.io/api/1.0";
   String _streamUrl = "https://config.ff.harness.io/api/1.0/stream";
   String _eventUrl = "https://events.ff.harness.io/api/1.0";
@@ -44,49 +41,41 @@ class CfConfigurationBuilder {
   Level _logLevel = Level.SEVERE;
 
   CfConfigurationBuilder setConfigUri(String configUrl) {
-
     this._configUrl = configUrl;
     return this;
   }
 
   CfConfigurationBuilder setStreamUrl(String streamUrl) {
-
     this._streamUrl = streamUrl;
     return this;
   }
 
   CfConfigurationBuilder setEventUrl(String eventUrl) {
-
     this._eventUrl = eventUrl;
     return this;
   }
 
   CfConfigurationBuilder setStreamEnabled(bool streamEnabled) {
-
     this._streamEnabled = streamEnabled;
     return this;
   }
 
   CfConfigurationBuilder setAnalyticsEnabled(bool analyticsEnabled) {
-
     this._analyticsEnabled = analyticsEnabled;
     return this;
   }
 
   CfConfigurationBuilder setPollingInterval(int pollingInterval) {
-
     this._pollingInterval = pollingInterval;
     return this;
   }
 
   CfConfigurationBuilder setLogLevel(Level logLevel) {
-
     this._logLevel = logLevel;
     return this;
   }
 
   CfConfiguration build() {
-
     return CfConfiguration._builder(this);
   }
 }

--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -8,6 +8,8 @@ class CfConfiguration {
   bool streamEnabled;
   bool analyticsEnabled;
   int pollingInterval;
+  // We use logLevel in CfClient.dart only, so no need to get a codec value
+  Level logLevel;
 
   CfConfiguration._builder(CfConfigurationBuilder builder)
       : configUrl = builder._configUrl,
@@ -15,7 +17,8 @@ class CfConfiguration {
         eventUrl  = builder._eventUrl,
         streamEnabled = builder._streamEnabled,
         analyticsEnabled = builder._analyticsEnabled,
-        pollingInterval = builder._pollingInterval;
+        pollingInterval = builder._pollingInterval,
+        logLevel = builder._logLevel;
 
   Map<String, dynamic> _toCodecValue() {
 
@@ -38,6 +41,7 @@ class CfConfigurationBuilder {
   bool _streamEnabled = true;
   bool _analyticsEnabled = true;
   int _pollingInterval = 60;
+  Level _logLevel = Level.SEVERE;
 
   CfConfigurationBuilder setConfigUri(String configUrl) {
 
@@ -72,6 +76,12 @@ class CfConfigurationBuilder {
   CfConfigurationBuilder setPollingInterval(int pollingInterval) {
 
     this._pollingInterval = pollingInterval;
+    return this;
+  }
+
+  CfConfigurationBuilder setLogLevel(Level logLevel) {
+
+    this._logLevel = logLevel;
     return this;
   }
 

--- a/lib/CfTarget.dart
+++ b/lib/CfTarget.dart
@@ -1,7 +1,6 @@
 part of ff_flutter_client_sdk;
 
 class CfTarget {
-
   String name;
   String identifier;
   bool anonymous;
@@ -14,7 +13,6 @@ class CfTarget {
         attributes = builder._attributes;
 
   Map<String, dynamic> _toCodecValue() {
-
     final Map<String, dynamic> result = <String, dynamic>{};
     result['identifier'] = identifier;
     result['name'] = name;

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -135,11 +135,15 @@ class FfFlutterClientSdkWebPlugin {
       _eventController.add({'event': EventType.SSE_END});
     }));
 
-    JavaScriptSDKClient.on(Event.CHANGED, allowInterop((flagInfo) {
-      ChangeEvent flag = flagInfo;
+    JavaScriptSDKClient.on(Event.CHANGED, allowInterop((changeInfo) {
+      FlagChange flagChange = changeInfo;
+      Map<String, dynamic> evaluationResponse = {
+        "flag": flagChange.flag,
+        "value": flagChange.value
+      };
       _eventController.add({
         'event': EventType.EVALUATION_CHANGE,
-        'data': flag // assuming flagInfo is some data you've retrieved
+        'data': evaluationResponse // assuming flagInfo is some data you've retrieved
       });
     }));
 
@@ -164,13 +168,8 @@ class FfFlutterClientSdkWebPlugin {
           break;
         case EventType.EVALUATION_CHANGE:
           log.fine('Internal event received EVALUATION_CHANGE');
-          var data = event['data'];
-          ChangeEvent flag = data;
-          Map<String, dynamic> eventMap = {
-            "flag": flag.flag,
-            "value": flag.value
-          };
-          _hostChannel.invokeMethod('evaluation_change', eventMap);
+          var evaluationResponse = event['data'];
+          _hostChannel.invokeMethod('evaluation_change', evaluationResponse);
           break;
       }
     });

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -18,6 +18,7 @@ class FfFlutterClientSdkWebPlugin {
   // The method calls that the core Flutter SDK can make
   static const _initializeMethodCall = 'initialize';
   static const _registerEventsListenerMethodCall = 'registerEventsListener';
+  static const _unRegisterEventsListenerMethodCall = 'unRegisterEventsListener';
   static const _variationMethodCall = 'variation';
 
   // Used to emit JavaScript SDK events to the host MethodChannel
@@ -68,6 +69,9 @@ class FfFlutterClientSdkWebPlugin {
         return await _invokeInitialize(call);
       case _registerEventsListenerMethodCall:
         _registerJsSDKStreamListeners();
+        break;
+      case _unRegisterEventsListenerMethodCall:
+        log.fine("test");
         break;
     }
   }

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -21,7 +21,8 @@ class JsSDKStreamCallbackFunctions {
   final Function changedFunction;
   final Function disconnectedFunction;
 
-  JsSDKStreamCallbackFunctions(this.connectedFunction, this.disconnectedFunction, this.changedFunction);
+  JsSDKStreamCallbackFunctions(
+      this.connectedFunction, this.disconnectedFunction, this.changedFunction);
 }
 
 class FfFlutterClientSdkWebPlugin {
@@ -116,7 +117,8 @@ class FfFlutterClientSdkWebPlugin {
     final initErrorCallback = (dynamic error) {
       // Same as above, defensive check.
       if (!initializationResult.isCompleted) {
-        log.severe("FF SDK failed to initialize: " + (error?.toString() ?? 'Auth error was empty'));
+        log.severe("FF SDK failed to initialize: " +
+            (error?.toString() ?? 'Auth error was empty'));
         initializationResult.complete(false);
       } else {
         log.fine(
@@ -156,17 +158,19 @@ class FfFlutterClientSdkWebPlugin {
         "flag": flagChange.flag,
         "value": flagChange.value
       };
-      _eventController.add({
-        'event': EventType.EVALUATION_CHANGE,
-        'data':
-            evaluationResponse
-      });
+      _eventController.add(
+          {'event': EventType.EVALUATION_CHANGE, 'data': evaluationResponse});
     };
     JavaScriptSDKClient.on(Event.CONNECTED, allowInterop(streamStartCallBack));
-    JavaScriptSDKClient.on(Event.DISCONNECTED, allowInterop(streamDisconnectedCallBack));
-    JavaScriptSDKClient.on(Event.CHANGED, allowInterop(streamEvaluationChangeCallBack));
+    JavaScriptSDKClient.on(
+        Event.DISCONNECTED, allowInterop(streamDisconnectedCallBack));
+    JavaScriptSDKClient.on(
+        Event.CHANGED, allowInterop(streamEvaluationChangeCallBack));
 
-    _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(streamStartCallBack, streamDisconnectedCallBack, streamEvaluationChangeCallBack);
+    _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
+        streamStartCallBack,
+        streamDisconnectedCallBack,
+        streamEvaluationChangeCallBack);
 
     _eventController.stream.listen((event) {
       switch (event['event']) {
@@ -195,20 +199,18 @@ class FfFlutterClientSdkWebPlugin {
 
   void _registerJsSDKStreamListeners(String uuid) {
     final callbacks = {
-      Event.CONNECTED: (_) => _eventController.add({'event': EventType.SSE_START}),
-
-      Event.DISCONNECTED: (_) => _eventController.add({'event': EventType.SSE_END}),
-
+      Event.CONNECTED: (_) =>
+          _eventController.add({'event': EventType.SSE_START}),
+      Event.DISCONNECTED: (_) =>
+          _eventController.add({'event': EventType.SSE_END}),
       Event.CHANGED: (changeInfo) {
         FlagChange flagChange = changeInfo;
         Map<String, dynamic> evaluationResponse = {
           "flag": flagChange.flag,
           "value": flagChange.value
         };
-        _eventController.add({
-          'event': EventType.EVALUATION_CHANGE,
-          'data': evaluationResponse
-        });
+        _eventController.add(
+            {'event': EventType.EVALUATION_CHANGE, 'data': evaluationResponse});
       }
     };
 
@@ -217,11 +219,10 @@ class FfFlutterClientSdkWebPlugin {
       JavaScriptSDKClient.on(event, allowInterop(callback!));
     }
 
-      _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
-          callbacks[Event.CONNECTED]!,
-          callbacks[Event.DISCONNECTED]!,
-          callbacks[Event.CHANGED]!
-      );
+    _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
+        callbacks[Event.CONNECTED]!,
+        callbacks[Event.DISCONNECTED]!,
+        callbacks[Event.CHANGED]!);
 
     _eventController.stream.listen((event) {
       switch (event['event']) {
@@ -237,7 +238,7 @@ class FfFlutterClientSdkWebPlugin {
           log.fine('Internal event received: SSE_RESUME');
           break;
         case EventType.EVALUATION_POLLING:
-        // TODO: The JavaScript SDK currently does not implement polling.
+          // TODO: The JavaScript SDK currently does not implement polling.
           break;
         case EventType.EVALUATION_CHANGE:
           log.fine('Internal event received EVALUATION_CHANGE');
@@ -246,16 +247,19 @@ class FfFlutterClientSdkWebPlugin {
           break;
       }
     });
-
   }
 
   void _unregisterJsSDKStreamListeners(String uuid) {
-    JsSDKStreamCallbackFunctions? registeredEvent = _uuidToEventListenerMap[uuid];
+    JsSDKStreamCallbackFunctions? registeredEvent =
+        _uuidToEventListenerMap[uuid];
     if (registeredEvent != null) {
       print("register: gonna unregister func on plugin side");
-      JavaScriptSDKClient.off(Event.CONNECTED, allowInterop(registeredEvent.connectedFunction));
-      JavaScriptSDKClient.off(Event.DISCONNECTED, allowInterop(registeredEvent.disconnectedFunction));
-      JavaScriptSDKClient.off(Event.CHANGED, allowInterop(registeredEvent.changedFunction));
+      JavaScriptSDKClient.off(
+          Event.CONNECTED, allowInterop(registeredEvent.connectedFunction));
+      JavaScriptSDKClient.off(Event.DISCONNECTED,
+          allowInterop(registeredEvent.disconnectedFunction));
+      JavaScriptSDKClient.off(
+          Event.CHANGED, allowInterop(registeredEvent.changedFunction));
     } else {
       log.warning("Attempted to unregister event listener, but the"
           "requested event listener was not found.");
@@ -286,6 +290,3 @@ class FfFlutterClientSdkWebPlugin {
     return object;
   }
 }
-
-
-

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -67,7 +67,8 @@ class FfFlutterClientSdkWebPlugin {
       case _initializeMethodCall:
         return await _invokeInitialize(call);
       case _registerEventsListenerMethodCall:
-        _registerJsSDKStreamListeners(call);
+        final uuid = call.arguments['uuid'];
+        _registerJsSDKStreamListeners(uuid);
         break;
       case _unRegisterEventsListenerMethodCall:
         log.fine("test");
@@ -138,7 +139,8 @@ class FfFlutterClientSdkWebPlugin {
 
   /// Registers the underlying JavaScript SDK event listeners, and emits events
   /// back to the core Flutter SDK using the plugin's host MethodChannel
-  void _registerJsSDKStreamListeners(MethodCall call) {
+  void _registerJsSDKStreamListeners(uuid) {
+
     final streamStartCallBack = (_) {
       _eventController.add({'event': EventType.SSE_START});
     };

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
 import 'package:logging/logging.dart';
+import 'package:uuid/uuid.dart';
 import 'CfClient.dart';
 import 'web_plugin_internal//FfJavascriptSDKInterop.dart';
 
@@ -189,9 +190,9 @@ class FfFlutterClientSdkWebPlugin {
 
   /// Helper function to register JavaScript SDK event listeners and store the
   /// function callback reference so they can be removed when requried.
-  void _registerAndStoreJSEventListener(String event, Function callback) {
+  void _registerAndStoreJSEventListener(String listenerUUID, String event, Function callback) {
     JavaScriptSDKClient.on(event, allowInterop(callback));
-    _uuidToEventListenerMap['your-uuid'] = JsSDKEventListener(event, callback);
+    _uuidToEventListenerMap[listenerUUID] = JsSDKEventListener(event, callback);
 
     _registeredEventListeners[event]!.add(callback);
   }

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -128,15 +128,17 @@ class FfFlutterClientSdkWebPlugin {
   /// Registers the underlying JavaScript SDK event listeners, and emits events
   /// back to the core Flutter SDK using the plugin's host MethodChannel
   void _registerJsSDKStreamListeners() {
-    JavaScriptSDKClient.on(Event.CONNECTED, allowInterop((_) {
+    final streamStartCallBack = (_) {
       _eventController.add({'event': EventType.SSE_START});
-    }));
+    };
+    _registerAndStoreJSEventListener(Event.CONNECTED, streamStartCallBack);
 
-    JavaScriptSDKClient.on(Event.DISCONNECTED, allowInterop((_) {
+    final streamDisconnectedCallBack = (_) {
       _eventController.add({'event': EventType.SSE_END});
-    }));
+    };
+    _registerAndStoreJSEventListener(Event.DISCONNECTED, streamDisconnectedCallBack);
 
-    JavaScriptSDKClient.on(Event.CHANGED, allowInterop((changeInfo) {
+    final streamEvaluationChangeCallBack = (changeInfo) {
       FlagChange flagChange = changeInfo;
       Map<String, dynamic> evaluationResponse = {
         "flag": flagChange.flag,
@@ -147,7 +149,8 @@ class FfFlutterClientSdkWebPlugin {
         'data':
             evaluationResponse // assuming flagInfo is some data you've retrieved
       });
-    }));
+    };
+    _registerAndStoreJSEventListener(Event.CHANGED, streamEvaluationChangeCallBack);
 
     _eventController.stream.listen((event) {
       switch (event['event']) {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -140,16 +140,15 @@ class FfFlutterClientSdkWebPlugin {
   /// Registers the underlying JavaScript SDK event listeners, and emits events
   /// back to the core Flutter SDK using the plugin's host MethodChannel
   void _registerJsSDKStreamListeners(uuid) {
-
     final streamStartCallBack = (_) {
       _eventController.add({'event': EventType.SSE_START});
     };
-    _registerAndStoreJSEventListener(Event.CONNECTED, streamStartCallBack);
+    _registerAndStoreJSEventListener(uuid, Event.CONNECTED, streamStartCallBack);
 
     final streamDisconnectedCallBack = (_) {
       _eventController.add({'event': EventType.SSE_END});
     };
-    _registerAndStoreJSEventListener(Event.DISCONNECTED, streamDisconnectedCallBack);
+    _registerAndStoreJSEventListener(uuid, Event.DISCONNECTED, streamDisconnectedCallBack);
 
     final streamEvaluationChangeCallBack = (changeInfo) {
       FlagChange flagChange = changeInfo;
@@ -163,7 +162,7 @@ class FfFlutterClientSdkWebPlugin {
             evaluationResponse
       });
     };
-    _registerAndStoreJSEventListener(Event.CHANGED, streamEvaluationChangeCallBack);
+    _registerAndStoreJSEventListener(uuid, Event.CHANGED, streamEvaluationChangeCallBack);
 
     _eventController.stream.listen((event) {
       switch (event['event']) {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -208,19 +208,4 @@ class FfFlutterClientSdkWebPlugin {
     });
     return object;
   }
-
-  Level logLevelFromName(String levelName) {
-    // Assuming you're using the 'logging' package for Level
-    switch (levelName) {
-      case 'SEVERE':
-        return Level.SEVERE;
-      case 'WARNING':
-        return Level.WARNING;
-      case 'INFO':
-        return Level.INFO;
-      // ... handle other levels
-      default:
-        return Level.SEVERE;
-    }
-  }
 }

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -37,7 +37,7 @@ class FfFlutterClientSdkWebPlugin {
   // The core Flutter SDK passes uuids over the method channel for each
   // listener that has been registered. This maps the UUID to the event and function callback
   // we pass to the JavaScript SDK, so they can be unregistered by users later.
-  Map<String, JsSDKEventListener> uuidToEventListenerMap = {};
+  Map<String, JsSDKEventListener> _uuidToEventListenerMap = {};
 
   // Used to send JavaScript SDK events to the Flutter
   // SDK Code.
@@ -191,6 +191,8 @@ class FfFlutterClientSdkWebPlugin {
   /// function callback reference so they can be removed when requried.
   void _registerAndStoreJSEventListener(String event, Function callback) {
     JavaScriptSDKClient.on(event, allowInterop(callback));
+    _uuidToEventListenerMap['your-uuid'] = JsSDKEventListener(event, callback);
+
     _registeredEventListeners[event]!.add(callback);
   }
 

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -187,7 +187,7 @@ class FfFlutterClientSdkWebPlugin {
   /// Helper function to turn a map into an object, which is the required
   /// type for interop with JavaScript objects
   Object _mapToJsObject(Map map) {
-    var object = newObject();
+    final object = newObject();
     map.forEach((k, v) {
       if (v is Map) {
         setProperty(object, k, _mapToJsObject(v));

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -73,7 +73,7 @@ class FfFlutterClientSdkWebPlugin {
     final _initializationResult = Completer<bool>();
 
     // Callback for the JavaScript SDK's READY event
-    void readyCallback([_]) {
+    final readyCallback = ([_]) {
       // While we shouldn't attempt to complete this completer more than once,
       // this is a defensive check and log if it is attempted.
       if (!_initializationResult.isCompleted) {
@@ -85,10 +85,10 @@ class FfFlutterClientSdkWebPlugin {
         log.info(
             'JavaScript SDK success response already handled. Ignoring subsequent response.');
       }
-    }
-
+    };
+    
     // Callback to handle errors that can occur when initializing.
-    void initErrorCallback(dynamic error) {
+    final initErrorCallback = (dynamic error) {
       log.severe(error ?? 'Auth error was empty');
       _removeJsSDKEventListener(Event.ERROR);
       _removeJsSDKEventListener(Event.READY);
@@ -99,22 +99,13 @@ class FfFlutterClientSdkWebPlugin {
         log.info(
             'JavaScript SDK failed response already handled. Ignoring subsequent response.');
       }
-    }
+    };
 
     _registerJsSDKEventListener(Event.READY, readyCallback);
     _registerJsSDKEventListener(Event.ERROR_AUTH, initErrorCallback);
 
     return _initializationResult.future;
   }
-
-  /// Callback to handle the JavaScript SDK's [Event.CHANGED] event
-  void _eventChangedCallBack() {}
-
-  /// Callback to handle the JavaScript SDK's [Event.CONNECTED] event
-  void _eventConnectedCallBack() {}
-
-  /// Callback to handle the JavaScript SDK's [Event.DISCONNECTED] event
-  void _eventDisconnectedCallBack() {}
 
   void _registerJsSDKEventListener(String event, Function callback) {
     if (_registeredListeners.contains(event)) {
@@ -126,6 +117,8 @@ class FfFlutterClientSdkWebPlugin {
     _registeredListeners.add(event);
   }
 
+  /// Registers the underlying JavaScript SDK event listeners, and emits events
+  /// back to the core Flutter SDK using the plugin's host MethodChannel
   void _registerJsSDKStreamListeners() {
     JavaScriptSDKClient.on(Event.CONNECTED, allowInterop((_) {
       _eventController.add({'event': EventType.SSE_START});
@@ -143,7 +136,8 @@ class FfFlutterClientSdkWebPlugin {
       };
       _eventController.add({
         'event': EventType.EVALUATION_CHANGE,
-        'data': evaluationResponse // assuming flagInfo is some data you've retrieved
+        'data':
+            evaluationResponse // assuming flagInfo is some data you've retrieved
       });
     }));
 
@@ -184,13 +178,13 @@ class FfFlutterClientSdkWebPlugin {
     }));
   }
 
-  // Callback used for logging errors that have been emitted by the JS SDK
+  /// Callback used for logging errors that have been emitted by the JS SDK
   void _errorCallback(String logString, dynamic error) {
     log.severe('$logString ' + (error ?? 'Error was empty'));
   }
 
-  // Helper function to turn a map into an object, which is the required
-  // type for interop with JavaScript objects
+  /// Helper function to turn a map into an object, which is the required
+  /// type for interop with JavaScript objects
   Object _mapToJsObject(Map map) {
     var object = newObject();
     map.forEach((k, v) {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -200,12 +200,15 @@ class FfFlutterClientSdkWebPlugin {
         _uuidToEventListenerMap[uuid];
     if (registeredEvent != null) {
       print("register: gonna unregister func on plugin side");
+
       JavaScriptSDKClient.off(
           Event.CONNECTED, allowInterop(registeredEvent.connectedFunction));
       JavaScriptSDKClient.off(Event.DISCONNECTED,
           allowInterop(registeredEvent.disconnectedFunction));
       JavaScriptSDKClient.off(
           Event.CHANGED, allowInterop(registeredEvent.changedFunction));
+
+      _uuidToEventListenerMap.remove(uuid);
     } else {
       log.warning("Attempted to unregister event listener, but the"
           "requested event listener was not found.");

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -3,6 +3,7 @@ library ff_web_plugin;
 
 import 'dart:async';
 import 'dart:js_util';
+import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
@@ -153,8 +154,13 @@ class FfFlutterClientSdkWebPlugin {
           _eventController.add({'event': EventType.SSE_END}),
       Event.CHANGED: (changeInfo) {
         FlagChange flagChange = changeInfo;
+        // The core Flutter SDK expects a map for json flag values,
+        // so we need to decode it instead of passing the json string that
+        // the JS SDK returns.
+        // Map<String, dynamic> value = (flagChange.kind == 'json') ? json.decode(flagChange.value) : flagChange.value;
         Map<String, dynamic> evaluationResponse = {
           "flag": flagChange.flag,
+          "kind": flagChange.kind,
           "value": flagChange.value
         };
         _eventController.add(

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -90,8 +90,7 @@ class FfFlutterClientSdkWebPlugin {
 
     // Used to return the result of initialize after the JavaScript SDK
     // emits either a READY or ERROR event.
-    final result = await _waitForInitializationResult();
-    return result;
+    return await _waitForInitializationResult();
   }
 
   Future<bool> _waitForInitializationResult() async {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -70,6 +70,7 @@ class FfFlutterClientSdkWebPlugin {
       // this is a defensive check and log if it is attempted.
       if (!initializationResult.isCompleted) {
         // Start listening for the required events emitted by the JavaScript SDK
+        // TODO I think these should be registered onDemand, as `registerEventListener` is invoked by Flutter core sdk
         registerJsSDKEventListener(Event.CHANGED, eventChangedCallBack);
         registerJsSDKEventListener(Event.CONNECTED, eventConnectedCallBack);
         registerJsSDKEventListener(Event.DISCONNECTED, eventDisconnectedCallBack);

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
 import 'package:logging/logging.dart';
-import 'package:uuid/uuid.dart';
 import 'CfClient.dart';
 import 'web_plugin_internal//FfJavascriptSDKInterop.dart';
 
@@ -213,16 +212,6 @@ class FfFlutterClientSdkWebPlugin {
       log.warning("Attempted to unregister event listener, but the"
           "requested event listener was not found.");
     }
-  }
-
-  // TODO, `off` needs the original cb function reference. Fix.
-  void _removeJsSDKEventListener(String event, Function callBack) {
-    JavaScriptSDKClient.off(event, allowInterop(callBack));
-  }
-
-  /// Callback used for logging errors that have been emitted by the JS SDK
-  void _errorCallback(String logString, dynamic error) {
-    log.severe('$logString ' + (error ?? 'Error was empty'));
   }
 
   /// Helper function to turn a map into an object, which is the required

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -15,9 +15,12 @@ external dynamic get window;
 
 class FfFlutterClientSdkWebPlugin {
   final log = Logger('FfFlutterClientSdkWebPluginLogger');
+  // The method calls that the core Flutter SDK can make
   static const _initializeMethodCall = 'initialize';
+  static const _registerEventsListenerMethodCall = 'registerEventsListener';
   static const _variationMethodCall = 'variation';
 
+  // Used to emit JavaScript SDK events to the host MethodChannel
   final StreamController<Map<String, dynamic>> _eventController =
       StreamController.broadcast();
 
@@ -145,21 +148,18 @@ class FfFlutterClientSdkWebPlugin {
     _eventController.stream.listen((event) {
       switch (event['event']) {
         case EventType.SSE_START:
+          log.fine('Internal event received: SSE_START');
           _hostChannel.invokeMethod('start');
-          log.fine('Internal event received SSE_START');
-
           break;
         case EventType.SSE_END:
+          log.fine('Internal event received: SSE_END');
           _hostChannel.invokeMethod('end');
-          log.fine('Internal event received SSE_START');
-
           break;
         case EventType.SSE_RESUME:
-          log.fine('Internal event received SSE_RESUME');
-
+          log.fine('Internal event received: SSE_RESUME');
           break;
         case EventType.EVALUATION_POLLING:
-          // TODO: Handle this case.
+          // TODO: The JavaScript SDK currently does not implement polling.
           break;
         case EventType.EVALUATION_CHANGE:
           log.fine('Internal event received EVALUATION_CHANGE');

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -143,60 +143,6 @@ class FfFlutterClientSdkWebPlugin {
 
   /// Registers the underlying JavaScript SDK event listeners, and emits events
   /// back to the core Flutter SDK using the plugin's host MethodChannel
-  void _registerJsSDKStreamListeners2(uuid) {
-    final streamStartCallBack = (_) {
-      _eventController.add({'event': EventType.SSE_START});
-    };
-
-    final streamDisconnectedCallBack = (_) {
-      _eventController.add({'event': EventType.SSE_END});
-    };
-
-    final streamEvaluationChangeCallBack = (changeInfo) {
-      FlagChange flagChange = changeInfo;
-      Map<String, dynamic> evaluationResponse = {
-        "flag": flagChange.flag,
-        "value": flagChange.value
-      };
-      _eventController.add(
-          {'event': EventType.EVALUATION_CHANGE, 'data': evaluationResponse});
-    };
-    JavaScriptSDKClient.on(Event.CONNECTED, allowInterop(streamStartCallBack));
-    JavaScriptSDKClient.on(
-        Event.DISCONNECTED, allowInterop(streamDisconnectedCallBack));
-    JavaScriptSDKClient.on(
-        Event.CHANGED, allowInterop(streamEvaluationChangeCallBack));
-
-    _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
-        streamStartCallBack,
-        streamDisconnectedCallBack,
-        streamEvaluationChangeCallBack);
-
-    _eventController.stream.listen((event) {
-      switch (event['event']) {
-        case EventType.SSE_START:
-          log.fine('Internal event received: SSE_START');
-          _hostChannel.invokeMethod('start');
-          break;
-        case EventType.SSE_END:
-          log.fine('Internal event received: SSE_END');
-          _hostChannel.invokeMethod('end');
-          break;
-        case EventType.SSE_RESUME:
-          log.fine('Internal event received: SSE_RESUME');
-          break;
-        case EventType.EVALUATION_POLLING:
-          // TODO: The JavaScript SDK currently does not implement polling.
-          break;
-        case EventType.EVALUATION_CHANGE:
-          log.fine('Internal event received EVALUATION_CHANGE');
-          var evaluationResponse = event['data'];
-          _hostChannel.invokeMethod('evaluation_change', evaluationResponse);
-          break;
-      }
-    });
-  }
-
   void _registerJsSDKStreamListeners(String uuid) {
     final callbacks = {
       Event.CONNECTED: (_) =>

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -154,10 +154,6 @@ class FfFlutterClientSdkWebPlugin {
           _eventController.add({'event': EventType.SSE_END}),
       Event.CHANGED: (changeInfo) {
         FlagChange flagChange = changeInfo;
-        // The core Flutter SDK expects a map for json flag values,
-        // so we need to decode it instead of passing the json string that
-        // the JS SDK returns.
-        // Map<String, dynamic> value = (flagChange.kind == 'json') ? json.decode(flagChange.value) : flagChange.value;
         Map<String, dynamic> evaluationResponse = {
           "flag": flagChange.flag,
           "kind": flagChange.kind,

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -53,6 +53,7 @@ class FfFlutterClientSdkWebPlugin {
   }
 
   Future<bool> invokeInitialize(MethodCall call) async {
+    log.info("message");
     final String apiKey = call.arguments['apiKey'];
     final Object target = mapToJsObject(call.arguments['target']);
     final Object options = mapToJsObject(call.arguments['configuration']);
@@ -75,11 +76,11 @@ class FfFlutterClientSdkWebPlugin {
       if (!initializationResult.isCompleted) {
         // Start listening for the required events emitted by the JavaScript SDK
         // TODO I think these should be registered onDemand, as `registerEventListener` is invoked by Flutter core sdk
-        registerJsSDKEventListener(Event.CHANGED, eventChangedCallBack);
-        registerJsSDKEventListener(Event.CONNECTED, eventConnectedCallBack);
-        registerJsSDKEventListener(
-            Event.DISCONNECTED, eventDisconnectedCallBack);
-
+        // registerJsSDKEventListener(Event.CHANGED, eventChangedCallBack);
+        // registerJsSDKEventListener(Event.CONNECTED, eventConnectedCallBack);
+        // registerJsSDKEventListener(
+        //     Event.DISCONNECTED, eventDisconnectedCallBack);
+        registerJsSDKStreamListeners();
         initializationResult.complete(true);
       } else {
         log.info(
@@ -155,20 +156,24 @@ class FfFlutterClientSdkWebPlugin {
         //   break;
         // ... handle other events
         case EventType.SSE_START:
-          _hostChannel.invokeMethod('start');
+          // _hostChannel.invokeMethod('start');
+          log.info('Internal event received SSE_START');
+
           break;
         case EventType.SSE_END:
-          _hostChannel.invokeMethod('end');
+          // _hostChannel.invokeMethod('end');
+          log.info('Internal event received SSE_START');
+
           break;
         case EventType.SSE_RESUME:
-          log.fine('Internal event received');
+          log.info('Internal event received SSE_RESUME');
 
           break;
         case EventType.EVALUATION_POLLING:
           // TODO: Handle this case.
           break;
         case EventType.EVALUATION_CHANGE:
-          // TODO: Handle this case.
+          log.info('Internal event received EVALUATION_CHANGE');
           break;
       }
     });
@@ -202,5 +207,20 @@ class FfFlutterClientSdkWebPlugin {
       }
     });
     return object;
+  }
+
+  Level logLevelFromName(String levelName) {
+    // Assuming you're using the 'logging' package for Level
+    switch (levelName) {
+      case 'SEVERE':
+        return Level.SEVERE;
+      case 'WARNING':
+        return Level.WARNING;
+      case 'INFO':
+        return Level.INFO;
+      // ... handle other levels
+      default:
+        return Level.SEVERE;
+    }
   }
 }

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -80,8 +80,6 @@ class FfFlutterClientSdkWebPlugin {
   }
 
   Future<bool> _waitForInitializationResult() {
-    // Used to return the result of initialize after the JavaScript SDK
-    // emits either a READY or ERROR event.
     final _initializationResult = Completer<bool>();
 
     // Callback for the JavaScript SDK's READY event. It returns a list of

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -180,7 +180,7 @@ class FfFlutterClientSdkWebPlugin {
     });
   }
 
-  // TODO - "off" currently not working correctly in the JS SDK. See: https://harness.atlassian.net/browse/FFM-8996
+  // TODO, `off` needs the original cb function reference. Fix.
   void removeJsSDKEventListener(String event) {
     JavaScriptSDKClient.off(event, allowInterop((dynamic error) {
       log.severe('Error removing event listener: ' +

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -22,10 +22,12 @@ class FfFlutterClientSdkWebPlugin {
   final StreamController<Map<String, dynamic>> _eventController =
       StreamController.broadcast();
 
-  // Keep track of unique events we are listening to from the JavaScript SDK
-  // Registering a listener doesn't return a reference we can keep track of,
-  // instead we just update this set with the event type.
-  // This prevents the accidental registering of more than one event type.
+  // Because the JavaScript SDK is a global window object, we need to keep track
+  // on this side of the event listeners we are registering, to avoid duplicate
+  // listeners being registered by this plugin. // TODO, so far I've only
+  // observed duplicate listeners being registered during development, when a hot
+  // reload initializes the client but the browser context is unaffected, so the window
+  // state remains.
   static Set<String> _registeredListeners = {};
 
   // This channel is used to send JavaScript SDK events to the Flutter
@@ -143,18 +145,9 @@ class FfFlutterClientSdkWebPlugin {
       });
     }));
 
-    // Add more listeners as needed...
 
-    // Flutter code can listen for these events and act accordingly.
     _eventController.stream.listen((event) {
       switch (event['event']) {
-        // case 'start':
-        //   _hostChannel.invokeMethod('start');
-        //   break;
-        // case 'end':
-        //   _hostChannel.invokeMethod('end');
-        //   break;
-        // ... handle other events
         case EventType.SSE_START:
           // _hostChannel.invokeMethod('start');
           log.info('Internal event received SSE_START');

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -170,7 +170,10 @@ class FfFlutterClientSdkWebPlugin {
           log.fine('Internal event received EVALUATION_CHANGE');
           var data = event['data'];
           ChangeEvent flag = data;
-          Map<String, dynamic> eventMap = {"flag": flag.flag, "value": flag.value};
+          Map<String, dynamic> eventMap = {
+            "flag": flag.flag,
+            "value": flag.value
+          };
           _hostChannel.invokeMethod('evaluation_change', eventMap);
           break;
       }
@@ -206,31 +209,4 @@ class FfFlutterClientSdkWebPlugin {
     });
     return object;
   }
-
-  // Helper function to turn a JavaScript object into a map, for sending change
-  // event data back to the core Flutter SDK code
-  Map jsObjectToMap(dynamic jsObject) {
-    Map result = {};
-    List keys = _objectKeys(jsObject);
-    for (dynamic key in keys) {
-      dynamic value = getProperty(jsObject, key);
-      List ?nestedKeys = objectKeys(value);
-      if ((nestedKeys ?? []).isNotEmpty) {
-        //nested property
-        result[key] = jsObjectToMap(value);
-      } else {
-        result[key] = value;
-      }
-    }
-    return result;
-  }
-
-  List<String>? objectKeys(dynamic jsObject) {
-    if (jsObject == null || jsObject is String || jsObject is num || jsObject is bool) return null;
-    return _objectKeys(jsObject);
-  }
-
-
 }
-
-

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -122,8 +122,8 @@ class FfFlutterClientSdkWebPlugin {
     };
 
     // Listen for the JavaScript SDK READY / ERROR_AUTH events to be emitted
-    _registerAndStoreJSEventListener(Event.READY, readyCallback);
-    _registerAndStoreJSEventListener(Event.ERROR_AUTH, initErrorCallback);
+    _registerJSEventListener(Event.READY, readyCallback);
+    _registerJSEventListener(Event.ERROR_AUTH, initErrorCallback);
 
     final result = await initializationResult.future;
 
@@ -193,8 +193,13 @@ class FfFlutterClientSdkWebPlugin {
   void _registerAndStoreJSEventListener(String listenerUUID, String event, Function callback) {
     JavaScriptSDKClient.on(event, allowInterop(callback));
     _uuidToEventListenerMap[listenerUUID] = JsSDKEventListener(event, callback);
+  }
 
-    _registeredEventListeners[event]!.add(callback);
+  /// Helper function to simply register JavaScript SDK event listeners. This is
+  /// for READY and AUTH_ERROR where we remove them in the same scope that they've
+  /// been registered, so no need to store them.
+  void _registerJSEventListener(String event, Function callback) {
+    JavaScriptSDKClient.on(event, allowInterop(callback));
   }
 
   void _unregisterJsSDKEventListener() {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -13,6 +13,15 @@ import 'web_plugin_internal//FfJavascriptSDKInterop.dart';
 @JS('window')
 external dynamic get window;
 
+// Type used to group the event and callback function used when registering
+// events with the JavaScript SDK
+class JsSDKEventListener {
+  final String event;
+  final Function function;
+
+  JsSDKEventListener(this.event, this.function);
+}
+
 class FfFlutterClientSdkWebPlugin {
   final log = Logger('FfFlutterClientSdkWebPluginLogger');
   // The method calls that the core Flutter SDK can make
@@ -25,22 +34,11 @@ class FfFlutterClientSdkWebPlugin {
   final StreamController<Map<String, dynamic>> _eventController =
       StreamController.broadcast();
 
-  // Store registered events and their function references, so that they can
-  // be removed later.
-  static Map<String, List<Function>> _registeredEventListeners = {
-    Event.READY: [],
-    Event.CONNECTED: [],
-    Event.DISCONNECTED: [],
-    Event.FLAG_LOADED: [],
-    Event.CACHE_LOADED: [],
-    Event.CHANGED: [],
-    Event.ERROR: [],
-    Event.ERROR_AUTH: [],
-    Event.ERROR_METRICS: [],
-    Event.ERROR_FETCH_FLAGS: [],
-    Event.ERROR_FETCH_FLAG: [],
-    Event.ERROR_STREAM: []
-  };
+  // The core Flutter SDK passes uuids over the method channel for each
+  // listener that has been registered. This maps the UUID to the event and function callback
+  // we pass to the JavaScript SDK, so they can be unregistered by users later.
+  Map<String, JsSDKEventListener> uuidToEventListenerMap = {};
+
   // Used to send JavaScript SDK events to the Flutter
   // SDK Code.
   static late MethodChannel _hostChannel;
@@ -224,3 +222,6 @@ class FfFlutterClientSdkWebPlugin {
     return object;
   }
 }
+
+
+

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -28,7 +28,7 @@ class FfFlutterClientSdkWebPlugin {
   // The method calls that the core Flutter SDK can make
   static const _initializeMethodCall = 'initialize';
   static const _registerEventsListenerMethodCall = 'registerEventsListener';
-  static const _unRegisterEventsListenerMethodCall = 'unregisterEventsListener';
+  static const _unregisterEventsListenerMethodCall = 'unregisterEventsListener';
   static const _variationMethodCall = 'variation';
 
   // Used to emit JavaScript SDK events to the host MethodChannel
@@ -70,9 +70,10 @@ class FfFlutterClientSdkWebPlugin {
         final uuid = call.arguments['uuid'];
         _registerJsSDKStreamListeners(uuid);
         break;
-      case _unRegisterEventsListenerMethodCall:
+      case _unregisterEventsListenerMethodCall:
+        final uuid = call.arguments['uuid'];
         log.fine("test");
-        _unregisterJsSDKEventListener();
+        _unregisterJsSDKStreamListeners(uuid);
         break;
     }
   }
@@ -203,8 +204,15 @@ class FfFlutterClientSdkWebPlugin {
     JavaScriptSDKClient.on(event, allowInterop(callback));
   }
 
-  void _unregisterJsSDKEventListener() {
-
+  void _unregisterJsSDKStreamListeners(String uuid) {
+    JsSDKEventListener? registeredEvent = _uuidToEventListenerMap[uuid];
+    if (registeredEvent != null) {
+      print("register: gonna unregister func on plugin side");
+      _removeJsSDKEventListener(registeredEvent.event, registeredEvent.function);
+    } else {
+      log.warning("Attempted to unregister event listener, but the"
+          "requested event listener was not found.");
+    }
   }
 
   // TODO, `off` needs the original cb function reference. Fix.

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -19,8 +19,8 @@ class FfFlutterClientSdkWebPlugin {
   static const _initializeMethodCall = 'initialize';
   static const _variationMethodCall = 'variation';
 
-  final StreamController<Map<String, dynamic>> _eventController = StreamController.broadcast();
-
+  final StreamController<Map<String, dynamic>> _eventController =
+      StreamController.broadcast();
 
   // Keep track of unique events we are listening to from the JavaScript SDK
   // Registering a listener doesn't return a reference we can keep track of,
@@ -77,7 +77,8 @@ class FfFlutterClientSdkWebPlugin {
         // TODO I think these should be registered onDemand, as `registerEventListener` is invoked by Flutter core sdk
         registerJsSDKEventListener(Event.CHANGED, eventChangedCallBack);
         registerJsSDKEventListener(Event.CONNECTED, eventConnectedCallBack);
-        registerJsSDKEventListener(Event.DISCONNECTED, eventDisconnectedCallBack);
+        registerJsSDKEventListener(
+            Event.DISCONNECTED, eventDisconnectedCallBack);
 
         initializationResult.complete(true);
       } else {
@@ -107,19 +108,13 @@ class FfFlutterClientSdkWebPlugin {
   }
 
   /// Callback to handle the JavaScript SDK's [Event.CHANGED] event
-  void eventChangedCallBack() {
-
-  }
+  void eventChangedCallBack() {}
 
   /// Callback to handle the JavaScript SDK's [Event.CONNECTED] event
-  void eventConnectedCallBack() {
-
-  }
+  void eventConnectedCallBack() {}
 
   /// Callback to handle the JavaScript SDK's [Event.DISCONNECTED] event
-  void eventDisconnectedCallBack() {
-
-  }
+  void eventDisconnectedCallBack() {}
 
   void registerJsSDKEventListener(String event, Function callback) {
     if (_registeredListeners.contains(event)) {
@@ -130,7 +125,6 @@ class FfFlutterClientSdkWebPlugin {
     JavaScriptSDKClient.on(event, allowInterop(callback));
     _registeredListeners.add(event);
   }
-
 
   void registerJsSDKStreamListeners() {
     JavaScriptSDKClient.on(Event.CONNECTED, allowInterop((_) {
@@ -144,10 +138,9 @@ class FfFlutterClientSdkWebPlugin {
     JavaScriptSDKClient.on(Event.CHANGED, allowInterop((flagInfo) {
       _eventController.add({
         'event': EventType.EVALUATION_CHANGE,
-        'data': flagInfo  // assuming flagInfo is some data you've retrieved
-      });    }));
-
-
+        'data': flagInfo // assuming flagInfo is some data you've retrieved
+      });
+    }));
 
     // Add more listeners as needed...
 
@@ -160,7 +153,7 @@ class FfFlutterClientSdkWebPlugin {
         // case 'end':
         //   _hostChannel.invokeMethod('end');
         //   break;
-      // ... handle other events
+        // ... handle other events
         case EventType.SSE_START:
           _hostChannel.invokeMethod('start');
           break;

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -68,7 +68,7 @@ class FfFlutterClientSdkWebPlugin {
       case _initializeMethodCall:
         return await _invokeInitialize(call);
       case _registerEventsListenerMethodCall:
-        _registerJsSDKStreamListeners();
+        _registerJsSDKStreamListeners(call);
         break;
       case _unRegisterEventsListenerMethodCall:
         log.fine("test");
@@ -131,7 +131,7 @@ class FfFlutterClientSdkWebPlugin {
 
   /// Registers the underlying JavaScript SDK event listeners, and emits events
   /// back to the core Flutter SDK using the plugin's host MethodChannel
-  void _registerJsSDKStreamListeners() {
+  void _registerJsSDKStreamListeners(MethodCall call) {
     final streamStartCallBack = (_) {
       _eventController.add({'event': EventType.SSE_START});
     };

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -146,7 +146,7 @@ class FfFlutterClientSdkWebPlugin {
 
     // Flutter code can listen for these events and act accordingly.
     _eventController.stream.listen((event) {
-      switch (EventType.SSE_START) {
+      switch (event['event']) {
         // case 'start':
         //   _hostChannel.invokeMethod('start');
         //   break;
@@ -161,7 +161,8 @@ class FfFlutterClientSdkWebPlugin {
           _hostChannel.invokeMethod('end');
           break;
         case EventType.SSE_RESUME:
-          // TODO: Handle this case.
+          log.fine('Internal event received');
+
           break;
         case EventType.EVALUATION_POLLING:
           // TODO: Handle this case.

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -114,6 +114,7 @@ class FfFlutterClientSdkWebPlugin {
     final initErrorCallback = (dynamic error) {
       // Same as above, defensive check.
       if (!_initializationResult.isCompleted) {
+        log.severe("Failed to initialize: " + (error?.toString() ?? 'Auth error was empty'));
         _initializationResult.complete(false);
       } else {
         log.fine(

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -105,19 +105,18 @@ class FfFlutterClientSdkWebPlugin {
       if (!_initializationResult.isCompleted) {
         _initializationResult.complete(true);
       } else {
-        log.info(
+        log.fine(
             'JavaScript SDK success response already handled. Ignoring subsequent response.');
       }
     };
 
     // Callback to handle errors that can occur when initializing.
     final initErrorCallback = (dynamic error) {
-      log.severe("Failed to initialize: " + (error?.toString() ?? 'Auth error was empty'));
       // Same as above, defensive check.
       if (!_initializationResult.isCompleted) {
         _initializationResult.complete(false);
       } else {
-        log.info(
+        log.fine(
             'JavaScript SDK failed response already handled. Ignoring subsequent response.');
       }
     };

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -146,7 +146,7 @@ class FfFlutterClientSdkWebPlugin {
     _eventController.stream.listen((event) {
       switch (event['event']) {
         case EventType.SSE_START:
-          _hostChannel.invokeMethod('start', null);
+          _hostChannel.invokeMethod('start');
           log.fine('Internal event received SSE_START');
 
           break;
@@ -164,6 +164,7 @@ class FfFlutterClientSdkWebPlugin {
           break;
         case EventType.EVALUATION_CHANGE:
           log.fine('Internal event received EVALUATION_CHANGE');
+          _hostChannel.invokeMethod('evaluation_change', jsObjectToMap(event['data']));
           break;
       }
     });
@@ -198,4 +199,32 @@ class FfFlutterClientSdkWebPlugin {
     });
     return object;
   }
+
+  // Helper function to turn a JavaScript object into a map, for sending change
+  // event data back to the core Flutter SDK code
+  Map jsObjectToMap(dynamic jsObject) {
+    Map result = {};
+    List keys = _objectKeys(jsObject);
+    for (dynamic key in keys) {
+      dynamic value = getProperty(jsObject, key);
+      List ?nestedKeys = objectKeys(value);
+      if ((nestedKeys ?? []).isNotEmpty) {
+        //nested property
+        result[key] = jsObjectToMap(value);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  List<String>? objectKeys(dynamic jsObject) {
+    if (jsObject == null || jsObject is String || jsObject is num || jsObject is bool) return null;
+    return _objectKeys(jsObject);
+  }
+
+
 }
+
+@JS('Object.keys')
+external List<String> _objectKeys(jsObject);

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -22,12 +22,10 @@ class FfFlutterClientSdkWebPlugin {
   final StreamController<Map<String, dynamic>> _eventController =
       StreamController.broadcast();
 
-  // Because the JavaScript SDK is a global window object, we need to keep track
-  // on this side of the event listeners we are registering, to avoid duplicate
-  // listeners being registered by this plugin. // TODO, so far I've only
-  // observed duplicate listeners being registered during development, when a hot
-  // reload initializes the client but the browser context is unaffected, so the window
-  // state remains.
+  // Keep track of unique events we are listening to from the JavaScript SDK
+  // Registering a listener doesn't return a reference we can keep track of,
+  // instead we just update this set with the event type.
+  // This prevents the accidental registering of more than one event type.
   static Set<String> _registeredListeners = {};
 
   // This channel is used to send JavaScript SDK events to the Flutter

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -13,6 +13,9 @@ import 'web_plugin_internal//FfJavascriptSDKInterop.dart';
 @JS('window')
 external dynamic get window;
 
+@JS('Object.keys')
+external List<String> _objectKeys(jsObject);
+
 final log = Logger('FfFlutterClientSdkWebPluginLogger');
 
 class FfFlutterClientSdkWebPlugin {
@@ -137,9 +140,10 @@ class FfFlutterClientSdkWebPlugin {
     }));
 
     JavaScriptSDKClient.on(Event.CHANGED, allowInterop((flagInfo) {
+      ChangeEvent flag = flagInfo;
       _eventController.add({
         'event': EventType.EVALUATION_CHANGE,
-        'data': flagInfo // assuming flagInfo is some data you've retrieved
+        'data': flag // assuming flagInfo is some data you've retrieved
       });
     }));
 
@@ -164,7 +168,10 @@ class FfFlutterClientSdkWebPlugin {
           break;
         case EventType.EVALUATION_CHANGE:
           log.fine('Internal event received EVALUATION_CHANGE');
-          _hostChannel.invokeMethod('evaluation_change', jsObjectToMap(event['data']));
+          var data = event['data'];
+          ChangeEvent flag = data;
+          Map<String, dynamic> eventMap = {"flag": flag.flag, "value": flag.value};
+          _hostChannel.invokeMethod('evaluation_change', eventMap);
           break;
       }
     });
@@ -226,5 +233,4 @@ class FfFlutterClientSdkWebPlugin {
 
 }
 
-@JS('Object.keys')
-external List<String> _objectKeys(jsObject);
+

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -147,7 +147,7 @@ class FfFlutterClientSdkWebPlugin {
       _eventController.add({
         'event': EventType.EVALUATION_CHANGE,
         'data':
-            evaluationResponse // assuming flagInfo is some data you've retrieved
+            evaluationResponse
       });
     };
     _registerAndStoreJSEventListener(Event.CHANGED, streamEvaluationChangeCallBack);

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
 import 'package:logging/logging.dart';
+import 'CfClient.dart';
 import 'web_plugin_internal//FfJavascriptSDKInterop.dart';
 
 @JS('window')
@@ -128,6 +129,43 @@ class FfFlutterClientSdkWebPlugin {
     }
     JavaScriptSDKClient.on(event, allowInterop(callback));
     _registeredListeners.add(event);
+  }
+
+
+  void registerJsSDKStreamListeners() {
+    JavaScriptSDKClient.on(EventType.SSE_START, allowInterop((_) {
+      _eventController.add({'event': 'start'});
+    }));
+
+    // Add more listeners as needed...
+
+    // Flutter code can listen for these events and act accordingly.
+    _eventController.stream.listen((event) {
+      switch (EventType.SSE_START) {
+        case 'start':
+          _hostChannel.invokeMethod('start');
+          break;
+        case 'end':
+          _hostChannel.invokeMethod('end');
+          break;
+      // ... handle other events
+        case EventType.SSE_START:
+          _hostChannel.invokeMethod('start');
+          break;
+        case EventType.SSE_RESUME:
+          // TODO: Handle this case.
+          break;
+        case EventType.SSE_END:
+          _hostChannel.invokeMethod('end');
+          break;
+        case EventType.EVALUATION_POLLING:
+          // TODO: Handle this case.
+          break;
+        case EventType.EVALUATION_CHANGE:
+          // TODO: Handle this case.
+          break;
+      }
+    });
   }
 
   // TODO - "off" currently not working correctly in the JS SDK. See: https://harness.atlassian.net/browse/FFM-8996

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -15,14 +15,17 @@ external dynamic get window;
 final log = Logger('FfFlutterClientSdkWebPluginLogger');
 
 class FfFlutterClientSdkWebPlugin {
-  static const initializeMethodCall = 'initialize';
-  static const variationMethodCall = 'variation';
+  static const _initializeMethodCall = 'initialize';
+  static const _variationMethodCall = 'variation';
+
+  final StreamController<Map<String, dynamic>> _eventController = StreamController.broadcast();
+
 
   // Keep track of unique events we are listening to from the JavaScript SDK
   // Registering a listener doesn't return a reference we can keep track of,
   // instead we just update this set with the event type.
   // This prevents the accidental registering of more than one event type.
-  static Set<String> registeredListeners = {};
+  static Set<String> _registeredListeners = {};
 
   // This channel is used to send JavaScript SDK events to the Flutter
   // SDK Code.
@@ -43,7 +46,7 @@ class FfFlutterClientSdkWebPlugin {
   /// Handles method calls over the [MethodChannel] for this plugin
   Future<dynamic> handleMethodCall(MethodCall call) async {
     switch (call.method) {
-      case initializeMethodCall:
+      case _initializeMethodCall:
         return await invokeInitialize(call);
     }
   }
@@ -118,13 +121,13 @@ class FfFlutterClientSdkWebPlugin {
   }
 
   void registerJsSDKEventListener(String event, Function callback) {
-    if (registeredListeners.contains(event)) {
+    if (_registeredListeners.contains(event)) {
       log.info(
           'Listener for $event already registered. Skipping subsequent registration.');
       return;
     }
     JavaScriptSDKClient.on(event, allowInterop(callback));
-    registeredListeners.add(event);
+    _registeredListeners.add(event);
   }
 
   // TODO - "off" currently not working correctly in the JS SDK. See: https://harness.atlassian.net/browse/FFM-8996

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -72,7 +72,8 @@ class FfFlutterClientSdkWebPlugin {
     // emits either a READY or ERROR event.
     final _initializationResult = Completer<bool>();
 
-    // Callback for the JavaScript SDK's READY event
+    // Callback for the JavaScript SDK's READY event. It returns a list of
+    // evaluations, but we don't need them in this plugin.
     final readyCallback = ([_]) {
       // While we shouldn't attempt to complete this completer more than once,
       // this is a defensive check and log if it is attempted.

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -21,11 +21,10 @@ class JsSDKStreamCallbackFunctions {
   final Function changedFunction;
   final Function disconnectedFunction;
 
-  JsSDKStreamCallbackFunctions({
-    required this.connectedFunction,
-    required this.disconnectedFunction,
-    required this.changedFunction
-  });
+  JsSDKStreamCallbackFunctions(
+      {required this.connectedFunction,
+      required this.disconnectedFunction,
+      required this.changedFunction});
 }
 
 class FfFlutterClientSdkWebPlugin {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -135,8 +135,8 @@ class FfFlutterClientSdkWebPlugin {
     // After READY or ERROR_AUTH has been emitted and we have a result,
     // then unregister these listeners from the JavaScript SDK as we don't
     // need them anymore.
-    _removeJsSDKEventListener(Event.READY, readyCallback);
-    _removeJsSDKEventListener(Event.ERROR_AUTH, initErrorCallback);
+    JavaScriptSDKClient.off(Event.READY, allowInterop(readyCallback));
+    JavaScriptSDKClient.off(Event.ERROR_AUTH, allowInterop(initErrorCallback));
 
     return result;
   }

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -20,8 +20,11 @@ class JsSDKStreamCallbackFunctions {
   final Function changedFunction;
   final Function disconnectedFunction;
 
-  JsSDKStreamCallbackFunctions(
-      this.connectedFunction, this.disconnectedFunction, this.changedFunction);
+  JsSDKStreamCallbackFunctions({
+    required this.connectedFunction,
+    required this.disconnectedFunction,
+    required this.changedFunction
+  });
 }
 
 class FfFlutterClientSdkWebPlugin {
@@ -165,9 +168,9 @@ class FfFlutterClientSdkWebPlugin {
     }
 
     _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
-        callbacks[Event.CONNECTED]!,
-        callbacks[Event.DISCONNECTED]!,
-        callbacks[Event.CHANGED]!);
+        connectedFunction: callbacks[Event.CONNECTED]!,
+        disconnectedFunction: callbacks[Event.DISCONNECTED]!,
+        changedFunction: callbacks[Event.CHANGED]!);
 
     _eventController.stream.listen((event) {
       switch (event['event']) {

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -133,30 +133,42 @@ class FfFlutterClientSdkWebPlugin {
 
 
   void registerJsSDKStreamListeners() {
-    JavaScriptSDKClient.on(EventType.SSE_START, allowInterop((_) {
-      _eventController.add({'event': 'start'});
+    JavaScriptSDKClient.on(Event.CONNECTED, allowInterop((_) {
+      _eventController.add({'event': EventType.SSE_START});
     }));
+
+    JavaScriptSDKClient.on(Event.DISCONNECTED, allowInterop((_) {
+      _eventController.add({'event': EventType.SSE_END});
+    }));
+
+    JavaScriptSDKClient.on(Event.CHANGED, allowInterop((flagInfo) {
+      _eventController.add({
+        'event': EventType.EVALUATION_CHANGE,
+        'data': flagInfo  // assuming flagInfo is some data you've retrieved
+      });    }));
+
+
 
     // Add more listeners as needed...
 
     // Flutter code can listen for these events and act accordingly.
     _eventController.stream.listen((event) {
       switch (EventType.SSE_START) {
-        case 'start':
-          _hostChannel.invokeMethod('start');
-          break;
-        case 'end':
-          _hostChannel.invokeMethod('end');
-          break;
+        // case 'start':
+        //   _hostChannel.invokeMethod('start');
+        //   break;
+        // case 'end':
+        //   _hostChannel.invokeMethod('end');
+        //   break;
       // ... handle other events
         case EventType.SSE_START:
           _hostChannel.invokeMethod('start');
           break;
-        case EventType.SSE_RESUME:
-          // TODO: Handle this case.
-          break;
         case EventType.SSE_END:
           _hostChannel.invokeMethod('end');
+          break;
+        case EventType.SSE_RESUME:
+          // TODO: Handle this case.
           break;
         case EventType.EVALUATION_POLLING:
           // TODO: Handle this case.

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -113,7 +113,7 @@ class FfFlutterClientSdkWebPlugin {
     final initErrorCallback = (dynamic error) {
       // Same as above, defensive check.
       if (!_initializationResult.isCompleted) {
-        log.severe("Failed to initialize: " + (error?.toString() ?? 'Auth error was empty'));
+        log.severe("FF SDK failed to initialize: " + (error?.toString() ?? 'Auth error was empty'));
         _initializationResult.complete(false);
       } else {
         log.fine(

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -141,7 +141,7 @@ class FfFlutterClientSdkWebPlugin {
 
   /// Registers the underlying JavaScript SDK event listeners, and emits events
   /// back to the core Flutter SDK using the plugin's host MethodChannel
-  void _registerJsSDKStreamListeners(uuid) {
+  void _registerJsSDKStreamListeners2(uuid) {
     final streamStartCallBack = (_) {
       _eventController.add({'event': EventType.SSE_START});
     };
@@ -191,6 +191,62 @@ class FfFlutterClientSdkWebPlugin {
           break;
       }
     });
+  }
+
+  void _registerJsSDKStreamListeners(String uuid) {
+    final callbacks = {
+      Event.CONNECTED: (_) => _eventController.add({'event': EventType.SSE_START}),
+
+      Event.DISCONNECTED: (_) => _eventController.add({'event': EventType.SSE_END}),
+
+      Event.CHANGED: (changeInfo) {
+        FlagChange flagChange = changeInfo;
+        Map<String, dynamic> evaluationResponse = {
+          "flag": flagChange.flag,
+          "value": flagChange.value
+        };
+        _eventController.add({
+          'event': EventType.EVALUATION_CHANGE,
+          'data': evaluationResponse
+        });
+      }
+    };
+
+    for (var event in callbacks.keys) {
+      var callback = callbacks[event];
+      JavaScriptSDKClient.on(event, allowInterop(callback!));
+    }
+
+      _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
+          callbacks[Event.CONNECTED]!,
+          callbacks[Event.DISCONNECTED]!,
+          callbacks[Event.CHANGED]!
+      );
+
+    _eventController.stream.listen((event) {
+      switch (event['event']) {
+        case EventType.SSE_START:
+          log.fine('Internal event received: SSE_START');
+          _hostChannel.invokeMethod('start');
+          break;
+        case EventType.SSE_END:
+          log.fine('Internal event received: SSE_END');
+          _hostChannel.invokeMethod('end');
+          break;
+        case EventType.SSE_RESUME:
+          log.fine('Internal event received: SSE_RESUME');
+          break;
+        case EventType.EVALUATION_POLLING:
+        // TODO: The JavaScript SDK currently does not implement polling.
+          break;
+        case EventType.EVALUATION_CHANGE:
+          log.fine('Internal event received EVALUATION_CHANGE');
+          var evaluationResponse = event['data'];
+          _hostChannel.invokeMethod('evaluation_change', evaluationResponse);
+          break;
+      }
+    });
+
   }
 
   void _unregisterJsSDKStreamListeners(String uuid) {

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -45,7 +45,8 @@ class Event {
 
 @JS()
 @anonymous
-class ChangeEvent {
+/// The payload for [Event.CHANGED].
+class FlagChange {
   external String get flag;
   external String get identifier;
   external String get value;

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -45,7 +45,7 @@ class Event {
 
 @JS()
 @anonymous
-/// The payload for [Event.CHANGED].
+/// The payload from [Event.CHANGED].
 class FlagChange {
   external String get flag;
   external String get identifier;

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -42,3 +42,12 @@ class Event {
   static const ERROR_FETCH_FLAG = 'fetch flag error';
   static const ERROR_STREAM = 'stream error';
 }
+
+@JS()
+@anonymous
+class ChangeEvent {
+  external String get flag;
+  external String get identifier;
+  external String get value;
+  external String get kind;
+}

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -45,6 +45,7 @@ class Event {
 
 @JS()
 @anonymous
+
 /// The payload from [Event.CHANGED].
 class FlagChange {
   external String get flag;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   logging: ^1.1.1
   flutter_web_plugins:
     sdk: flutter
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# What
1. Implements the Flutter SDK's `registerEventListener` method.  When a user calls this, the plugin will:

a) Register `CONNECTED` / `DISCONNECTED`/ `ON_CHANGE` events with the JavaScript SDK. 
b) These events are emitted from the plugin to the core Flutter SDK then to the users application. 
c) Keeps track of the callback function the user registered in their function code using a UUID, and then on the plugin side it maps that to the callback function the plugin uses to register the JavaScript SDK events. 

2. Implements `unregisterEventsListener` when a user calls this, the plugin will:
a) using the users callback function, get the mapped uuid and pass it to the plugin, which will remove the JavaScript SDK emitters and also the plugin specific emitters. Note: the Android/iOS plugins don't do this, and this will need implemented there. See: https://harness.slack.com/archives/C02AR2E4F99/p1692189077120299

3. Standardises SSE event evaluation value types with the `xVariation` evaluation value types for Android. The SSE types are sent as Strings, but the xVariation types are the actual type e.g. `bool` `int` etc. this resulted in essentially incorrect SSE evaluations unless the user casted the response. Note: the web plugin via the JS SDK already sends the correct values, and the iOS SDK will need a minor update so that its events emit the `kind` attribute. I will handle the iOS release as part of the Web epic.

# Testing
Manual, extensive. 
- Events are registered correctly and SSE events come in, and are passed in the correct response format to the core Flutter SDK. This was tested by toggling all of the different flag types, and getting their response in a sample application.
- Events are unregisertered correctly on the Flutter and JS SDK side. 
- Android/iOS testing and these SDKs behave as normal.
