### PR TITLE
FFM-9030 Add polling and improve JS SDK Options

### DIFF
--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -5,6 +5,7 @@ class CfConfiguration {
   String streamUrl;
   String eventUrl;
   bool streamEnabled;
+  bool pollingEnabled;
   bool analyticsEnabled;
   int pollingInterval;
   // We use logLevel in CfClient.dart only, so no need to get a codec value
@@ -16,6 +17,7 @@ class CfConfiguration {
         eventUrl = builder._eventUrl,
         streamEnabled = builder._streamEnabled,
         analyticsEnabled = builder._analyticsEnabled,
+        pollingEnabled = builder._pollingEnabled,
         pollingInterval = builder._pollingInterval,
         logLevel = builder._logLevel;
 
@@ -27,6 +29,8 @@ class CfConfiguration {
     result['streamEnabled'] = streamEnabled;
     result['analyticsEnabled'] = analyticsEnabled;
     result['pollingInterval'] = pollingInterval;
+    // Needed for Web platform as the JS SDK exposes this
+    result['pollingEnabled'] = pollingInterval;
     return result;
   }
 }
@@ -36,6 +40,7 @@ class CfConfigurationBuilder {
   String _streamUrl = "https://config.ff.harness.io/api/1.0/stream";
   String _eventUrl = "https://events.ff.harness.io/api/1.0";
   bool _streamEnabled = true;
+  bool _pollingEnabled = true;
   bool _analyticsEnabled = true;
   int _pollingInterval = 60;
   Level _logLevel = Level.SEVERE;
@@ -57,6 +62,11 @@ class CfConfigurationBuilder {
 
   CfConfigurationBuilder setStreamEnabled(bool streamEnabled) {
     this._streamEnabled = streamEnabled;
+    return this;
+  }
+
+  CfConfigurationBuilder setPollingEnabled(bool pollingEnabled) {
+    this._pollingEnabled = pollingEnabled;
     return this;
   }
 

--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -40,7 +40,7 @@ class CfConfigurationBuilder {
   String _streamUrl = "https://config.ff.harness.io/api/1.0/stream";
   String _eventUrl = "https://events.ff.harness.io/api/1.0";
   bool _streamEnabled = true;
-  bool _pollingEnabled = true;
+  bool _pollingEnabled = false;
   bool _analyticsEnabled = true;
   int _pollingInterval = 60;
   Level _logLevel = Level.SEVERE;

--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -10,6 +10,9 @@ class CfConfiguration {
   int pollingInterval;
   // We use logLevel in CfClient.dart only, so no need to get a codec value
   Level logLevel;
+  // Separate log level for the JavaScript SDK - TODO, need same thing
+  // for Android / iOS and should standardise.
+  bool debugEnabled;
 
   CfConfiguration._builder(CfConfigurationBuilder builder)
       : configUrl = builder._configUrl,
@@ -19,7 +22,8 @@ class CfConfiguration {
         analyticsEnabled = builder._analyticsEnabled,
         pollingEnabled = builder._pollingEnabled,
         pollingInterval = builder._pollingInterval,
-        logLevel = builder._logLevel;
+        logLevel = builder._logLevel,
+        debugEnabled = builder.debugEnabled;
 
   Map<String, dynamic> _toCodecValue() {
     final Map<String, dynamic> result = <String, dynamic>{};
@@ -31,6 +35,7 @@ class CfConfiguration {
     result['pollingInterval'] = pollingInterval;
     // Needed for Web platform as the JS SDK exposes this
     result['pollingEnabled'] = pollingInterval;
+    result['debugEnabled'] = debugEnabled;
     return result;
   }
 }
@@ -44,6 +49,7 @@ class CfConfigurationBuilder {
   bool _analyticsEnabled = true;
   int _pollingInterval = 60;
   Level _logLevel = Level.SEVERE;
+  bool debugEnabled = false;
 
   CfConfigurationBuilder setConfigUri(String configUrl) {
     this._configUrl = configUrl;
@@ -82,6 +88,11 @@ class CfConfigurationBuilder {
 
   CfConfigurationBuilder setLogLevel(Level logLevel) {
     this._logLevel = logLevel;
+    return this;
+  }
+
+  CfConfigurationBuilder setDebugEnabled(bool debugEnabled) {
+    this.debugEnabled = debugEnabled;
     return this;
   }
 

--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -34,7 +34,7 @@ class CfConfiguration {
     result['analyticsEnabled'] = analyticsEnabled;
     result['pollingInterval'] = pollingInterval;
     // Needed for Web platform as the JS SDK exposes this
-    result['pollingEnabled'] = pollingInterval;
+    result['pollingEnabled'] = pollingEnabled;
     result['debugEnabled'] = debugEnabled;
     return result;
   }

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -101,13 +101,17 @@ class FfFlutterClientSdkWebPlugin {
     // The JS SDK uses `debug` for its option, so we need to send this
     if (options['debugEnabled'] == true) {
       options.remove('debugEnabled');
+      options.remove('debugEnabled');
       options['debug'] = true;
     } else {
       // Just remove the key if it's set to false as the JS SDK won't use it
       options.remove('debugEnabled');
     }
-    final Object optionsAsJSObj = _mapToJsObject(options);
-    final response = JavaScriptSDK.initialize(apiKey, target, optionsAsJSObj);
+    final Map test = {"streamEnabled": false};
+    final Object optionsAsJSObj = _mapToJsObject(test);
+    var optionsInstance = Options(streamEnabled: false, pollingEnabled: true, debug: true);
+
+    final response = JavaScriptSDK.initialize(apiKey, target, optionsInstance);
 
     // The JavaScript SDK returns the client instance, whether or not
     // the initialization was successful. We set a reference to it on

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -105,8 +105,8 @@ class FfFlutterClientSdkWebPlugin {
         eventUrl: options['eventUrl'],
         pollingInterval: options['pollingInterval'],
         pollingEnabled: options['pollingEnabled'],
-        streamEnabled: options['debugEnabled'],
-        debug: true);
+        streamEnabled: options['streamEnabled'],
+        debug: options['debugEnabled']);
 
     final response = JavaScriptSDK.initialize(apiKey, target, optionsInstance);
 

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -96,8 +96,18 @@ class FfFlutterClientSdkWebPlugin {
   Future<bool> _invokeInitialize(MethodCall call) async {
     final String apiKey = call.arguments['apiKey'];
     final Object target = _mapToJsObject(call.arguments['target']);
-    final Object options = _mapToJsObject(call.arguments['configuration']);
-    final response = JavaScriptSDK.initialize(apiKey, target, options);
+
+    final Map options = call.arguments['configuration'];
+    // The JS SDK uses `debug` for its option, so we need to send this
+    if (options['debugEnabled'] == true) {
+      options.remove('debugEnabled');
+      options['debug'] = true;
+    } else {
+      // Just remove the key if it's set to false as the JS SDK won't use it
+      options.remove('debugEnabled');
+    }
+    final Object optionsAsJSObj = _mapToJsObject(options);
+    final response = JavaScriptSDK.initialize(apiKey, target, optionsAsJSObj);
 
     // The JavaScript SDK returns the client instance, whether or not
     // the initialization was successful. We set a reference to it on

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -98,7 +98,7 @@ class FfFlutterClientSdkWebPlugin {
     final Object target = _mapToJsObject(call.arguments['target']);
     final Map flutterOptions = call.arguments['configuration'];
 
-    var javascriptSdkOptions = Options(
+    final javascriptSdkOptions = Options(
         baseUrl: flutterOptions['configUrl'],
         eventUrl: flutterOptions['eventUrl'],
         pollingInterval: flutterOptions['pollingInterval'],

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -99,17 +99,14 @@ class FfFlutterClientSdkWebPlugin {
 
     final Map options = call.arguments['configuration'];
     // The JS SDK uses `debug` for its option, so we need to send this
-    if (options['debugEnabled'] == true) {
-      options.remove('debugEnabled');
-      options.remove('debugEnabled');
-      options['debug'] = true;
-    } else {
-      // Just remove the key if it's set to false as the JS SDK won't use it
-      options.remove('debugEnabled');
-    }
-    final Map test = {"streamEnabled": false};
-    final Object optionsAsJSObj = _mapToJsObject(test);
-    var optionsInstance = Options(streamEnabled: false, pollingEnabled: true, debug: true);
+
+    var optionsInstance = Options(
+        baseUrl: options['configUrl'],
+        eventUrl: options['eventUrl'],
+        pollingInterval: options['pollingInterval'],
+        pollingEnabled: options['pollingEnabled'],
+        streamEnabled: options['debugEnabled'],
+        debug: true);
 
     final response = JavaScriptSDK.initialize(apiKey, target, optionsInstance);
 

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -96,19 +96,17 @@ class FfFlutterClientSdkWebPlugin {
   Future<bool> _invokeInitialize(MethodCall call) async {
     final String apiKey = call.arguments['apiKey'];
     final Object target = _mapToJsObject(call.arguments['target']);
+    final Map flutterOptions = call.arguments['configuration'];
 
-    final Map options = call.arguments['configuration'];
-    // The JS SDK uses `debug` for its option, so we need to send this
+    var javascriptSdkOptions = Options(
+        baseUrl: flutterOptions['configUrl'],
+        eventUrl: flutterOptions['eventUrl'],
+        pollingInterval: flutterOptions['pollingInterval'],
+        pollingEnabled: flutterOptions['pollingEnabled'],
+        streamEnabled: flutterOptions['streamEnabled'],
+        debug: flutterOptions['debugEnabled']);
 
-    var optionsInstance = Options(
-        baseUrl: options['configUrl'],
-        eventUrl: options['eventUrl'],
-        pollingInterval: options['pollingInterval'],
-        pollingEnabled: options['pollingEnabled'],
-        streamEnabled: options['streamEnabled'],
-        debug: options['debugEnabled']);
-
-    final response = JavaScriptSDK.initialize(apiKey, target, optionsInstance);
+    final response = JavaScriptSDK.initialize(apiKey, target, javascriptSdkOptions);
 
     // The JavaScript SDK returns the client instance, whether or not
     // the initialization was successful. We set a reference to it on

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -47,7 +47,6 @@ class Event {
 
 @JS()
 @anonymous
-
 /// The options payload for [JavaScriptSDK.initialize].
 class Options {
   external String get baseUrl;
@@ -63,7 +62,6 @@ class Options {
 
 @JS()
 @anonymous
-
 /// The payload from [Event.CHANGED].
 class FlagChange {
   external String get flag;
@@ -74,7 +72,6 @@ class FlagChange {
 
 @JS()
 @anonymous
-
 /// The payload from [JavaScriptSDKClient.variation].
 class VariationResult {
   external dynamic get value;

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -48,7 +48,7 @@ class Event {
 @JS()
 @anonymous
 
-/// The payload from [Event.CHANGED].
+/// The options payload for [JavaScriptSDK.initialize].
 class Options {
   external String get baseUrl;
   external String get eventUrl;

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -10,7 +10,7 @@ class JavaScriptSDK {
   static const initializeFunction = 'initialize';
 
   external static dynamic initialize(
-      String apiKey, Object target, Object options);
+      String apiKey, Object target, Options options);
 }
 
 // Represents the JavaScript SDK Client instance. Once we've initialized the
@@ -42,6 +42,18 @@ class Event {
   static const ERROR_FETCH_FLAGS = 'fetch flags error';
   static const ERROR_FETCH_FLAG = 'fetch flag error';
   static const ERROR_STREAM = 'stream error';
+}
+
+@JS()
+@anonymous
+/// The payload from [Event.CHANGED].
+class Options {
+  external bool get streamEnabled;
+  external bool get pollingEnabled;
+  external bool get debug;
+
+  external factory Options({bool streamEnabled, bool pollingEnabled, bool debug});
+
 }
 
 @JS()

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -25,7 +25,8 @@ class JavaScriptSDKClient {
 
   external static dynamic on(dynamic eventType, Function callback);
   external static dynamic off(dynamic eventType, Function callback);
-  external static dynamic variation(dynamic flagIdentifier, dynamic defaultValue, bool withDebug);
+  external static dynamic variation(
+      dynamic flagIdentifier, dynamic defaultValue, bool withDebug);
 }
 
 // Represents the events that the JavaScript SDK Client can emit
@@ -46,18 +47,23 @@ class Event {
 
 @JS()
 @anonymous
+
 /// The payload from [Event.CHANGED].
 class Options {
+  external String get baseUrl;
+  external String get eventUrl;
+  external int get pollingInterval;
   external bool get streamEnabled;
   external bool get pollingEnabled;
   external bool get debug;
 
-  external factory Options({bool streamEnabled, bool pollingEnabled, bool debug});
-
+  external factory Options(
+      {String baseUrl, String eventUrl, int pollingInterval, bool streamEnabled, bool pollingEnabled, bool debug});
 }
 
 @JS()
 @anonymous
+
 /// The payload from [Event.CHANGED].
 class FlagChange {
   external String get flag;
@@ -68,6 +74,7 @@ class FlagChange {
 
 @JS()
 @anonymous
+
 /// The payload from [JavaScriptSDKClient.variation].
 class VariationResult {
   external dynamic get value;


### PR DESCRIPTION
# What
Implements the options required to enable polling in the JS SDK - note, that is currently under review - https://github.com/harness/ff-javascript-client-sdk/pull/98 and testing has been carried out with an RC 

# Testing
Manual 
- Enable streaming 
- Enable streaming and polling (streaming takes precedence but falls back to polling in event of disconnect)
- Disable streaming and enable polling 
- Disable streaming and polling

