### PR TITLE
FFM-9405 Flutter Web: Emit polling evaluations to core SDK 

### DIFF
--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -273,6 +273,7 @@ class CfClient {
   /// Client's method to deregister and cleanup internal resources used by SDK
   Future<void> destroy() async {
     _listenerSet.clear();
+    log.fine('Shutting down Harness Feature Flags SDK Client');
     return _channel.invokeMethod('destroy');
   }
 }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -130,10 +130,13 @@ class CfClient {
       List<EvaluationResponse> resultList = [];
 
       list.forEach((element) {
+        final dynamic value = element["value"];
+        final String? kind = element["kind"];
+        final dynamic parsedValue =
+        kind != null ? convertValueByKind(kind, value) : value;
         String flag = element["flag"];
-        dynamic value = element["value"];
 
-        resultList.add(EvaluationResponse(flag, value));
+        resultList.add(EvaluationResponse(flag, parsedValue));
       });
 
       _listenerSet.forEach((element) {

--- a/lib/CfConfiguration.dart
+++ b/lib/CfConfiguration.dart
@@ -5,7 +5,6 @@ class CfConfiguration {
   String streamUrl;
   String eventUrl;
   bool streamEnabled;
-  bool pollingEnabled;
   bool analyticsEnabled;
   int pollingInterval;
   // We use logLevel in CfClient.dart only, so no need to get a codec value
@@ -20,7 +19,6 @@ class CfConfiguration {
         eventUrl = builder._eventUrl,
         streamEnabled = builder._streamEnabled,
         analyticsEnabled = builder._analyticsEnabled,
-        pollingEnabled = builder._pollingEnabled,
         pollingInterval = builder._pollingInterval,
         logLevel = builder._logLevel,
         debugEnabled = builder.debugEnabled;
@@ -34,7 +32,6 @@ class CfConfiguration {
     result['analyticsEnabled'] = analyticsEnabled;
     result['pollingInterval'] = pollingInterval;
     // Needed for Web platform as the JS SDK exposes this
-    result['pollingEnabled'] = pollingEnabled;
     result['debugEnabled'] = debugEnabled;
     return result;
   }
@@ -45,7 +42,6 @@ class CfConfigurationBuilder {
   String _streamUrl = "https://config.ff.harness.io/api/1.0/stream";
   String _eventUrl = "https://events.ff.harness.io/api/1.0";
   bool _streamEnabled = true;
-  bool _pollingEnabled = false;
   bool _analyticsEnabled = true;
   int _pollingInterval = 60;
   Level _logLevel = Level.SEVERE;
@@ -68,11 +64,6 @@ class CfConfigurationBuilder {
 
   CfConfigurationBuilder setStreamEnabled(bool streamEnabled) {
     this._streamEnabled = streamEnabled;
-    return this;
-  }
-
-  CfConfigurationBuilder setPollingEnabled(bool pollingEnabled) {
-    this._pollingEnabled = pollingEnabled;
     return this;
   }
 

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -112,7 +112,9 @@ class FfFlutterClientSdkWebPlugin {
         baseUrl: flutterOptions['configUrl'],
         eventUrl: flutterOptions['eventUrl'],
         pollingInterval: flutterOptions['pollingInterval'],
-        pollingEnabled: flutterOptions['pollingEnabled'],
+        // Enable polling by default for the JS SDK, so we can fallback to polling
+        // of stream fails.
+        pollingEnabled: true,
         streamEnabled: flutterOptions['streamEnabled'],
         debug: flutterOptions['debugEnabled']);
 

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -177,8 +177,10 @@ class FfFlutterClientSdkWebPlugin {
   /// back to the core Flutter SDK using the plugin's host MethodChannel
   void _registerJsSDKStreamListeners(String uuid) {
     final callbacks = {
+      // The JavaScript SDK's `CONNECTED` event is emitted when an SSE connection
+      // has been lost and reestablished
       Event.CONNECTED: (_) =>
-          _eventController.add({'event': EventType.SSE_START}),
+          _eventController.add({'event': EventType.SSE_RESUME}),
       Event.DISCONNECTED: (_) =>
           _eventController.add({'event': EventType.SSE_END}),
       Event.CHANGED: (changeInfo) {
@@ -190,7 +192,9 @@ class FfFlutterClientSdkWebPlugin {
         };
         _eventController.add(
             {'event': EventType.EVALUATION_CHANGE, 'data': evaluationResponse});
-      }
+      },
+      Event.POLLING: (_) =>
+          _eventController.add({'event': EventType.EVALUATION_POLLING}),
     };
 
 
@@ -216,6 +220,7 @@ class FfFlutterClientSdkWebPlugin {
           break;
         case EventType.SSE_RESUME:
           log.fine('Internal event received: SSE_RESUME');
+          _hostChannel.invokeMethod('resume');
           break;
         case EventType.EVALUATION_POLLING:
           break;

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -19,12 +19,12 @@ external dynamic get window;
 class JsSDKStreamCallbackFunctions {
   final Function connectedFunction;
   final Function changedFunction;
-  final Function disconnectedFunction;
+  final Function stoppedFunction;
   final Function pollingChangedFunction;
 
   JsSDKStreamCallbackFunctions(
       {required this.connectedFunction,
-      required this.disconnectedFunction,
+      required this.stoppedFunction,
       required this.pollingChangedFunction,
       required this.changedFunction});
 }
@@ -194,9 +194,8 @@ class FfFlutterClientSdkWebPlugin {
             {'event': EventType.EVALUATION_CHANGE, 'data': evaluationResponse});
       },
       Event.POLLING_CHANGED: (polledFlags) {
-        List<FlagChange> flags = polledFlags;
-        List<Map<String, dynamic>> evaluationResponses =
-            flags.map((flagChange) {
+        dynamic flags = polledFlags;
+        List<dynamic> evaluationResponses = flags.map((flagChange) {
           return {
             "flag": flagChange.flag,
             "kind": flagChange.kind,
@@ -217,7 +216,7 @@ class FfFlutterClientSdkWebPlugin {
 
     _uuidToEventListenerMap[uuid] = JsSDKStreamCallbackFunctions(
         connectedFunction: callbacks[Event.CONNECTED]!,
-        disconnectedFunction: callbacks[Event.DISCONNECTED]!,
+        stoppedFunction: callbacks[Event.STOPPED]!,
         changedFunction: callbacks[Event.CHANGED]!,
         pollingChangedFunction: callbacks[Event.POLLING_CHANGED]!);
 
@@ -238,9 +237,8 @@ class FfFlutterClientSdkWebPlugin {
         case EventType.EVALUATION_POLLING:
           log.fine('Internal event received EVALUATION_POLLING');
           final pollingEvaluations = event['data'];
-
-          _hostChannel.invokeMethod('evaluation_polling');
-
+          _hostChannel.invokeMethod(
+              'evaluation_polling', {'evaluationData': pollingEvaluations});
           break;
         case EventType.EVALUATION_CHANGE:
           log.fine('Internal event received EVALUATION_CHANGE');
@@ -257,8 +255,8 @@ class FfFlutterClientSdkWebPlugin {
     if (callBackFunctions != null) {
       JavaScriptSDKClient.off(
           Event.CONNECTED, allowInterop(callBackFunctions.connectedFunction));
-      JavaScriptSDKClient.off(Event.DISCONNECTED,
-          allowInterop(callBackFunctions.disconnectedFunction));
+      JavaScriptSDKClient.off(
+          Event.STOPPED, allowInterop(callBackFunctions.stoppedFunction));
       JavaScriptSDKClient.off(
           Event.CHANGED, allowInterop(callBackFunctions.changedFunction));
 

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -32,11 +32,13 @@ class FfFlutterClientSdkWebPlugin {
   // The method calls that the core Flutter SDK can make
   static const _initializeMethodCall = 'initialize';
   static const _registerEventsListenerMethodCall = 'registerEventsListener';
-  static const _unregisterEventsListenerMethodCall = 'unregisterEventsListener';
   static const _boolVariationMethodCall = 'boolVariation';
   static const _stringVariationMethodCall = 'stringVariation';
   static const _numberVariationMethodCall = 'numberVariation';
   static const _jsonVariationMethodCall = 'jsonVariation';
+  static const _unregisterEventsListenerMethodCall = 'unregisterEventsListener';
+  static const _destroyMethodCall = 'destroy';
+
 
   // Used to emit JavaScript SDK events to the host MethodChannel
   final StreamController<Map<String, dynamic>> _eventController =
@@ -81,6 +83,9 @@ class FfFlutterClientSdkWebPlugin {
         final uuid = call.arguments['uuid'];
         log.fine("test");
         _unregisterJsSDKStreamListeners(uuid);
+        break;
+      case _destroyMethodCall:
+        JavaScriptSDKClient.close();
         break;
       default:
         if (call.method == _boolVariationMethodCall ||
@@ -251,6 +256,16 @@ class FfFlutterClientSdkWebPlugin {
       return jsonDecode(result.value);
     }
     return result.value;
+  }
+
+  void destroy() {
+    // Cleanup JavaScript SDK resources
+    JavaScriptSDKClient.close();
+
+    // Cleanup Dart resources
+    _eventController.close();
+    _uuidToEventListenerMap.clear();
+    _hostChannel.setMethodCallHandler(null);
   }
 
   /// Helper function to turn a map into an object, which is the required

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -85,7 +85,7 @@ class FfFlutterClientSdkWebPlugin {
         _unregisterJsSDKStreamListeners(uuid);
         break;
       case _destroyMethodCall:
-        JavaScriptSDKClient.close();
+        destroy();
         break;
       default:
         if (call.method == _boolVariationMethodCall ||

--- a/lib/FfFlutterClientSDKWebPlugin.dart
+++ b/lib/FfFlutterClientSDKWebPlugin.dart
@@ -267,10 +267,9 @@ class FfFlutterClientSdkWebPlugin {
     // Cleanup JavaScript SDK resources
     JavaScriptSDKClient.close();
 
-    // Cleanup Dart resources
+    // Cancel any JS SDK subscriptions that may have been registered
     _eventSubscription?.cancel();
     _uuidToEventListenerMap.clear();
-    _hostChannel.setMethodCallHandler(null);
   }
 
   /// Helper function to turn a map into an object, which is the required

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -34,6 +34,7 @@ class JavaScriptSDKClient {
 class Event {
   static const READY = 'ready';
   static const CONNECTED = 'connected';
+  static const STOPPED = 'stopped';
   static const DISCONNECTED = 'disconnected';
   static const FLAG_LOADED = 'flags loaded';
   static const CACHE_LOADED = 'cache loaded';

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -75,6 +75,7 @@ class FlagChange {
   external String get kind;
 }
 
+
 @JS()
 @anonymous
 /// The payload from [JavaScriptSDKClient.variation].

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -38,6 +38,9 @@ class Event {
   static const FLAG_LOADED = 'flags loaded';
   static const CACHE_LOADED = 'cache loaded';
   static const CHANGED = 'changed';
+  static const POLLING = 'polling';
+  static const POLLING_STOPPED = 'polling stopped';
+  static const POLLING_CHANGED = 'polling changed';
   static const ERROR = 'error';
   static const ERROR_AUTH = 'auth error';
   static const ERROR_METRICS = 'metrics error';

--- a/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
+++ b/lib/web_plugin_internal/FfJavascriptSDKInterop.dart
@@ -27,6 +27,7 @@ class JavaScriptSDKClient {
   external static dynamic off(dynamic eventType, Function callback);
   external static dynamic variation(
       dynamic flagIdentifier, dynamic defaultValue, bool withDebug);
+  external static dynamic close();
 }
 
 // Represents the events that the JavaScript SDK Client can emit


### PR DESCRIPTION
# What
Polling events that come through from the JS SDK now include a `POLLING_CHANGED` event with the evaluations payload. This change consumes that event, and forwards the payload in the correct response to the existing core SDK code. Also adds an enhancement that if the `kind` value is present (currently supported on JS / Android) then it will convert the evaluation value to its correct type, instead of a string. 

# Testing
Manual