### PR TITLE
FFM-10359 Fix `exhaustive when` Kotlin error / Upgrade Kotlin and Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ pubspec.lock
 .idea
 .idea/*
 .DS_Store
+
+gradle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.1
+
+Changes:
+
+* Adds support for Kotlin version 1.7.x for Android projects. Previously, compilation would fail
+due to Kotlin compilation issues.
+* Upgrades Feature Flags Android SDK to 1.2.3, which ensures the SDK will not crash the application
+should initialization fails. For full details of all Feature Flags Android SDK relases, see: https://github.com/harness/ff-android-client-sdk/releases
+
+
 ## 2.1.0
 
 Changes:

--- a/android/.idea/compiler.xml
+++ b/android/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -4,17 +4,14 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="JDK" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -5,7 +5,8 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleHome" value="$USER_HOME$/.sdkman/candidates/gradle/8.5" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -40,6 +40,6 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.2.2'
+    implementation 'io.harness:ff-android-client-sdk:1.2.3'
 
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'io.harness.flutter_cfsdk'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -22,9 +22,9 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
+    namespace = "io.harness.fluttersdk"
     compileSdkVersion 30
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:1.1.4'
+    implementation 'io.harness:ff-android-client-sdk:1.2.2'
 
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
 
 android {
     namespace = "io.harness.fluttersdk"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.harness.flutter_cfsdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -14,15 +14,15 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 import io.harness.cfsdk.CfClient
 import io.harness.cfsdk.CfConfiguration
-import io.harness.cfsdk.cloud.core.model.Evaluation
 import io.harness.cfsdk.cloud.model.Target
-import io.harness.cfsdk.cloud.oksse.EventsListener
-import io.harness.cfsdk.cloud.oksse.model.StatusEvent
+import io.harness.cfsdk.cloud.sse.EventsListener
+import io.harness.cfsdk.cloud.sse.StatusEvent
 import org.json.JSONArray
 import org.json.JSONObject
-import java.lang.Exception
 import java.util.concurrent.*;
 import io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
+import io.harness.cfsdk.cloud.openapi.client.model.Evaluation
+import kotlin.Exception
 
 /** FfFlutterClientSdkPlugin */
 class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
@@ -96,28 +96,33 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
 
             CfClient.getInstance().initialize(
 
-                    application,
-                    key,
-                    conf,
-                    targetInstance
+                application,
+                key,
+                conf,
+                targetInstance
 
-                ) { auth, execResult ->
-                    if (execResult.error == null) {
+            ) { auth, execResult ->
+                if (execResult.error == null) {
 
-                        postToMainThread {
-                            print(auth.environment)
+                    postToMainThread {
+                        print(auth.environment)
 
-                            Handler(Looper.getMainLooper()).post {
+                        Handler(Looper.getMainLooper()).post {
 
-                                result.success(execResult.isSuccess())
-                            }
-
+                            result.success(execResult.isSuccess())
                         }
+
                     }
-                    else {
-                        result.error("authError","Error when initializing SDK", execResult.error.localizedMessage )
-                    }
+                } else {
+                    result.error(
+                        "authError",
+                        "Error when initializing SDK",
+                        execResult.error.localizedMessage
+                    )
                 }
+            }
+
+
         }
     }
 
@@ -138,18 +143,21 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                         hostChannel.invokeMethod("start", null)
                     }
                 }
+
                 StatusEvent.EVENT_TYPE.SSE_END -> {
                     postToMainThread {
                         hostChannel.invokeMethod("end", null)
                     }
                 }
+
                 StatusEvent.EVENT_TYPE.SSE_RESUME -> {
                     postToMainThread {
                         hostChannel.invokeMethod("resume", null)
                     }
                 }
+
                 StatusEvent.EVENT_TYPE.EVALUATION_CHANGE -> {
-                    val evaluation = it.extractPayload<Evaluation>()
+                    val evaluation = it.extractEvaluationPayload()
                     val content = evaluationToMap(evaluation)
                     postToMainThread {
                         hostChannel.invokeMethod("evaluation_change", content)
@@ -158,7 +166,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
 
                 StatusEvent.EVENT_TYPE.EVALUATION_RELOAD -> {
 
-                    val evaluationList = it.extractPayload<List<Evaluation>>()
+                    val evaluationList = it.extractEvaluationListPayload()
 
                     val resultList = evaluationList.map { evaluation ->
                         evaluationToMap(evaluation)
@@ -248,6 +256,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
             is Boolean, is Number, is String -> {
                 value
             }
+
             is ArrayList<*> -> {
                 val jsonArr = JSONArray()
                 value.forEach {
@@ -255,6 +264,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                 }
                 jsonArr
             }
+
             else -> {
                 val jsonObj = JSONObject()
                 (value as HashMap<*, *>).forEach {
@@ -270,6 +280,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
             is Boolean, is Number, is String -> {
                 jsonElement.toString()
             }
+
             is JSONArray -> {
                 val res = ArrayList<Any?>()
                 for (i in 0 until jsonElement.length()) {
@@ -277,6 +288,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                 }
                 res
             }
+
             is JSONObject -> {
                 val res = HashMap<String, Any?>()
                 jsonElement.keys().forEach {
@@ -284,6 +296,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                 }
                 res
             }
+
             else -> {
                 null
             }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -94,7 +94,7 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
             val targetInstance = Target().identifier(target)
 
 
-                CfClient.getInstance().initialize(
+            CfClient.getInstance().initialize(
 
                     application,
                     key,
@@ -149,35 +149,10 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                     }
                 }
                 StatusEvent.EVENT_TYPE.EVALUATION_CHANGE -> {
-                    // TODO - there is a bug in Android that can sometimes send the change event in an ArrayList
-                    // instead of an Evaluation. This can happen when the SDK disconnects from the stream -> a flag is toggles -> and it reconnects.
-                    // This is a temporary solution until the bug can be fixed there.
-
-                    try {
-                        val evaluation = it.extractPayload<Evaluation>()
-                        val content = evaluationToMap(evaluation)
-
-                        postToMainThread {
-                            hostChannel.invokeMethod("evaluation_change", content)
-                        }
-                    } catch (e: Exception) {
-                        // We assume the first exception is due to a type mismatch.
-                        // Attempt to extract as a list.
-                        try {
-                            val evaluationList = it.extractPayload<List<Evaluation>>()
-                            val firstEvaluation = evaluationList.firstOrNull() // Safely get the first item or null
-                            if (firstEvaluation != null) {
-                                val content = evaluationToMap(firstEvaluation)
-
-                                postToMainThread {
-                                    hostChannel.invokeMethod("evaluation_change", content)
-                                }
-                            } else {
-                                // Handle the case where the list might be empty or null
-                            }
-                        } catch (e: Exception) {
-                            // Handle other errors, possibly logging them or taking some other action.
-                        }
+                    val evaluation = it.extractPayload<Evaluation>()
+                    val content = evaluationToMap(evaluation)
+                    postToMainThread {
+                        hostChannel.invokeMethod("evaluation_change", content)
                     }
                 }
 
@@ -195,6 +170,9 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                         hostChannel.invokeMethod("evaluation_polling", content)
                     }
                 }
+
+                StatusEvent.EVENT_TYPE.EVALUATION_REMOVE ->
+                    TODO()
             }
             println("internal received event ${it.eventType.name}")
         }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -171,10 +171,14 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                     }
                 }
 
-                StatusEvent.EVENT_TYPE.EVALUATION_REMOVE ->
-                    TODO()
+                // We don't need to notify users of internal events, as the underlying
+                // SDKs handle events like `EVALUATION_REMOVE` appropriately.
+                else -> {
+                    if (it != null) {
+                        println("internal received event ${it.eventType.name}")
+                    } else println("internal received event")
+                }
             }
-            println("internal received event ${it.eventType.name}")
         }
         CfClient.getInstance().registerEventsListener(listener)
     }

--- a/examples/getting_started/android/build.gradle
+++ b/examples/getting_started/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()

--- a/examples/getting_started/pubspec.yaml
+++ b/examples/getting_started/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  ff_flutter_client_sdk: 2.1.0
+  ff_flutter_client_sdk: 2.1.1
   english_words: ^4.0.0
   flutter_hooks: ^0.18.4
   flutter_dotenv: ^5.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:


### PR DESCRIPTION
# What
Since Kotlin 1.7.x, `when` statements must be exhaustive. We didn't catch this because our sample applications target older Kotlin versions. 
This change adds a new clause to handle internal events that we don't need to pas into users, and upgrades Kotlin and Gradle files.

# Testing
Manual sample application using Kotlin 1.7.2 