### PR TITLE
FFM-10501 Handle already initialized on Android

### DIFF
--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -308,12 +308,12 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
                     try {
                         invokeInitialize(call, result)
                       // The Android SDK only throws this if the SDK
-                      // is already initialized. We can hit this if the back button
+                      // is already initialized. We can encounter this if the back button
                       // is used to minimize/close the Flutter app, then re-opened.
                       // In this case, we know the Android SDK is already initialized so we can
                       // just return a success to the core Flutter code.
                     } catch (e: IllegalStateException) {
-                        println("Android SDK already successfully initialized. Returning positive result without initializing.")
+                        println("Android SDK already successfully initialized. Returning success result without initializing.")
                         result.success(true)
                     }
                 }

--- a/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
+++ b/android/src/main/kotlin/io/harness/flutter_cfsdk/FfFlutterClientSdkPlugin.kt
@@ -304,7 +304,19 @@ class FfFlutterClientSdkPlugin : FlutterPlugin, MethodCallHandler {
 
             when (call.method) {
 
-                "initialize" -> invokeInitialize(call, result)
+                "initialize" ->  {
+                    try {
+                        invokeInitialize(call, result)
+                      // The Android SDK only throws this if the SDK
+                      // is already initialized. We can hit this if the back button
+                      // is used to minimize/close the Flutter app, then re-opened.
+                      // In this case, we know the Android SDK is already initialized so we can
+                      // just return a success to the core Flutter code.
+                    } catch (e: IllegalStateException) {
+                        println("Android SDK already successfully initialized. Returning positive result without initializing.")
+                        result.success(true)
+                    }
+                }
 
                 "stringVariation" -> {
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   logging: ^1.1.1
   flutter_web_plugins:
     sdk: flutter
-  uuid: ^3.0.7
+  uuid: ^4.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# What
When an Android app is minimised using the back button, Flutter specific resources are closed by default. However, the Android SDK doesn't use Flutter's lifecycle-specific events and remains open. Consequently, when the Flutter app is reopened from the multi-task view, it re-triggers initialization causing an uncaught exception in the already running Android SDK.

The fix is to add a try-catch block for the `IllegalStateException` that is thrown by the Android SDK when its already initialized at the time of call to `initialize`.  In this case, the Android plugin now returns a positive result without attempting to initialize again.

Also bumps `uuid` 

# Testing with back button and home button
- Debug and release mode. The correct SDK state is observed and the app does not crash
- Streaming works as expected


# Testing `uuid` major version upgrade
- Flutter for Web sample app working correctly in all aspects