### PR TITLE
FFM-10516 Fix `destroy` not completing correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.3
+
+Fixes:
+
+* Fixes `CFClient.destroy` method not returning `Future` correctly
+
+
 ## 2.1.2
 
 Fixes:

--- a/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
@@ -201,9 +201,8 @@ public class SwiftFfFlutterClientSdkPlugin: NSObject, FlutterPlugin {
 				}
 
             case .destroy:
-                CfClient.sharedInstance.destroy { result in
-                    DispatchQueue.main.async {
-                        switch result {
+                CfClient.sharedInstance.destroy { destroyed in
+                        switch destroyed {
                         case .success:
                             print("SDK destroyed successfully.")
                         case .failure(let reason):
@@ -211,7 +210,7 @@ public class SwiftFfFlutterClientSdkPlugin: NSObject, FlutterPlugin {
                         }
                         result(true)
                     }
-                }
+
 		}
 	}
 

--- a/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
+++ b/ios/Classes/SwiftFfFlutterClientSdkPlugin.swift
@@ -200,8 +200,18 @@ public class SwiftFfFlutterClientSdkPlugin: NSObject, FlutterPlugin {
                 }
 				}
 
-			case .destroy:
-				CfClient.sharedInstance.destroy()
+            case .destroy:
+                CfClient.sharedInstance.destroy { result in
+                    DispatchQueue.main.async {
+                        switch result {
+                        case .success:
+                            print("SDK destroyed successfully.")
+                        case .failure(let reason):
+                            print("Failed to destroy SDK: \(reason)")
+                        }
+                        result(true)
+                    }
+                }
 		}
 	}
 

--- a/ios/ff_flutter_client_sdk.podspec
+++ b/ios/ff_flutter_client_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |ff|
   ff.name             = 'ff_flutter_client_sdk'
-  ff.version          = '1.1.3'
+  ff.version          = '1.0.3'
   ff.summary          = 'Flutter SDK for Harness Feature Flags Management'
   ff.description      = <<-DESC
 Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
@@ -16,7 +16,7 @@ Feature Flag Management platform from Harness. Flutter SDK can be used to integr
   ff.source_files = 'Classes/**/*'
 
   ff.dependency 'Flutter'
-  ff.dependency 'ff-ios-client-sdk', '1.1.2'
+  ff.dependency 'ff-ios-client-sdk', '1.1.3'
   ff.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/ff_flutter_client_sdk.podspec
+++ b/ios/ff_flutter_client_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |ff|
   ff.name             = 'ff_flutter_client_sdk'
-  ff.version          = '1.0.3'
+  ff.version          = '1.1.3'
   ff.summary          = 'Flutter SDK for Harness Feature Flags Management'
   ff.description      = <<-DESC
 Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:


### PR DESCRIPTION
# What
A fix is pending in the iOS SDK which adds a completion handler to the `destroy` method, so that the Flutter SDK iOS plugin can determine if the SDK has shut down, and to return the `result` 

# Why
The iOS plugin is not returning the `result`, which is causing the SDK to hang. 

# Testing
Manual, using locally published version of iOS SDK