### PR TITLE
FFM-11625 Bump Android SDK Version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.1
+
+Fixes and Enhancements:
+
+*  Upgrades Feature Flags Android SDK to 2.2.0
+
 ## 2.2.0
 
 Fixes and Enhancements:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:2.0.2'
+    implementation 'io.harness:ff-android-client-sdk:2.2.0'
 
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ff_flutter_client_sdk
 description: Feature Flag Management platform from Harness. Flutter SDK can be used to integrate with the platform in your Flutter applications.
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/harness/ff-flutter-client-sdk
 
 environment:


### PR DESCRIPTION
# What
An issue was raised : https://github.com/harness/ff-flutter-client-sdk/issues/37  that is reporting a `Reply already submitted` error in the latest version of the SDK 2.2.0 .  If the user pins the prior 2.1.3, they don't see the error.  The difference between versions is the new one uses the new v2 of the underlying FF-Android-SDK.

The version of the v2 Android SDK 2.0.1 has a bug where the initialise callback can be invoked more than once, and I theorise it could be the cause of the reply being submitted again.  This PR bumps the Android SDK to the latest version 2.2.0, where this bug has been fixed. 

# Testing
I have not been able to reproduce the `Reply already submitted` error. But I have tested the SDK lifecyle events in the usual way using a sample application. 