### PR TITLE
FFM-11625 Synchronize `close` on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+
     }
 }
 
@@ -40,6 +41,6 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.harness:ff-android-client-sdk:2.2.0'
+    implementation 'io.harness:ff-android-client-sdk:2.2.1'
 
 }

--- a/examples/getting_started/lib/main.dart
+++ b/examples/getting_started/lib/main.dart
@@ -87,13 +87,15 @@ class _FlagState extends State<FlagState> {
     }
   }
 
-  void destroyFFClient() {
-    CfClient.getInstance().destroy();
+  Future<void> destroyFFClient() async {
+    await CfClient.getInstance().destroy();
     CfClient.getInstance().unregisterEventsListener(_eventListener);
   }
 
-  Future<void> initialiseFFClient(String apiKey, CfConfiguration conf, CfTarget target) async {
-      var initResult = await CfClient.getInstance().initialize(apiKey, conf, target);
+  Future<void> initialiseFFClient(
+      String apiKey, CfConfiguration conf, CfTarget target) async {
+    var initResult =
+        await CfClient.getInstance().initialize(apiKey, conf, target);
     if (initResult.success) {
       print("Successfully initialized client");
 
@@ -102,7 +104,6 @@ class _FlagState extends State<FlagState> {
 
       // Setup Event Handler
       CfClient.getInstance().registerEventsListener(_eventListener);
-
     } else {
       print("Failed to initialize client, serving defaults");
       await flagVariations();
@@ -125,8 +126,7 @@ class _FlagState extends State<FlagState> {
         break;
 
       case EventType.EVALUATION_POLLING:
-        List<EvaluationResponse> evals =
-        (data as List<EvaluationResponse>);
+        List<EvaluationResponse> evals = (data as List<EvaluationResponse>);
 
         for (final eval in evals) {
           if (_flagValues.containsKey(eval.flag)) {
@@ -139,7 +139,8 @@ class _FlagState extends State<FlagState> {
 
       case EventType.EVALUATION_DELETE:
         String flag = data;
-        print("Flag '$flag' has been deleted, evaluating flags again to fall back to default variation for that flag");
+        print(
+            "Flag '$flag' has been deleted, evaluating flags again to fall back to default variation for that flag");
         flagVariations();
         break;
 
@@ -154,22 +155,26 @@ class _FlagState extends State<FlagState> {
 
   Future<void> flagVariations() async {
     // Evaluate flag and set initial state
-    var boolVariation = await CfClient.getInstance().boolVariation(boolFlagName, false);
+    var boolVariation =
+        await CfClient.getInstance().boolVariation(boolFlagName, false);
     setState(() {
       _flagValues[boolFlagName] = boolVariation;
     });
 
-    var jsonVariation = await CfClient.getInstance().jsonVariation(jsonFlagName, {});
+    var jsonVariation =
+        await CfClient.getInstance().jsonVariation(jsonFlagName, {});
     setState(() {
       _flagValues[jsonFlagName] = jsonVariation;
     });
 
-    var stringVariation = await CfClient.getInstance().stringVariation(stringFlagName, "default");
+    var stringVariation =
+        await CfClient.getInstance().stringVariation(stringFlagName, "default");
     setState(() {
       _flagValues[stringFlagName] = stringVariation;
     });
 
-    var numberVariation = await CfClient.getInstance().numberVariation(numberFlagName, 1);
+    var numberVariation =
+        await CfClient.getInstance().numberVariation(numberFlagName, 1);
     setState(() {
       _flagValues[numberFlagName] = numberVariation;
     });

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -314,4 +314,13 @@ class CfClient {
     log.fine('Shutting down Harness Feature Flags SDK Client');
     return _channel.invokeMethod('destroy');
   }
+
+  /// Like [destroy] but returns a bool to indicate if the SDK succesfully
+  /// closed.
+  Future<bool> destroyWithResult() async {
+    _listenerSet.clear();
+    log.fine('Shutting down Harness Feature Flags SDK Client');
+    bool result = await _channel.invokeMethod('destroy');
+    return result;
+  }
 }

--- a/lib/CfClient.dart
+++ b/lib/CfClient.dart
@@ -314,13 +314,4 @@ class CfClient {
     log.fine('Shutting down Harness Feature Flags SDK Client');
     return _channel.invokeMethod('destroy');
   }
-
-  /// Like [destroy] but returns a bool to indicate if the SDK succesfully
-  /// closed.
-  Future<bool> destroyWithResult() async {
-    _listenerSet.clear();
-    log.fine('Shutting down Harness Feature Flags SDK Client');
-    bool result = await _channel.invokeMethod('destroy');
-    return result;
-  }
 }


### PR DESCRIPTION
# What
The underlying Android SDK did not notify if `close()` completed succesfully, and the Flutter SDK just returned the future immediately.  This resulted in the SDK crashing with a `Reply already submitted` exception if the SDK was initialized and closed within quick succession. 

This fix bumps the Android SDK to 2.2.1 which adds a new synchronized `close` method, and updates the Android plugin to consume the new method.  This ensures that the `close` method and `initialize` method can be syncrhonized correctly, removing the `Reply already submitted` crash.

# Testing
Manual 
 - Android SDK 2.2.1 published to local maven repository, and calling `initialize` and `close` tens of times. 
